### PR TITLE
feat: Create empty workflow for updating lint rules

### DIFF
--- a/.github/workflows/update-lint-rules.yaml
+++ b/.github/workflows/update-lint-rules.yaml
@@ -1,0 +1,14 @@
+name: Update Lint Rules
+
+# TODO:
+#   Set schedule event as soon as update mechanism is implemented.
+#   https://docs.github.com/actions/using-workflows/events-that-trigger-workflows#schedule
+on:
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3


### PR DESCRIPTION
## Issue

#5 

※ Doesn't close the issue.

## Overview (Required)

Create empty workflow for updating lint rules.
Set schedule event as soon as update mechanism is implemented.

## Links

- https://docs.github.com/actions/using-workflows/manually-running-a-workflow
- https://docs.github.com/actions/using-workflows/events-that-trigger-workflows#schedule

## Screenshot

-