### PR TITLE
Create a workflow for publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,12 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish:
+    permissions:
+      id-token: write # Required for authentication using OIDC
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1

--- a/.pubignore
+++ b/.pubignore
@@ -1,0 +1,3 @@
+.github/*
+docs/*
+tools/*


### PR DESCRIPTION
## Issue

- close #11 

## Overview (Required)

Create a workflow for publishing to pub.dev.

## Links

- https://dart.dev/tools/pub/automated-publishing#configuring-a-github-action-workflow-for-publishing-to-pubdev
- https://dart.dev/tools/pub/publishing#preparing-to-publish

## Screenshot

It has been confirmed through the command whether it can be published or not.

```shell
% dart pub publish --dry-run

Resolving dependencies... 
Got dependencies!
Publishing yumemi_lints 1.0.0 to https://pub.dev:
├── CHANGELOG.md (<1 KB)
├── LICENSE (1 KB)
├── README.md (2 KB)
├── example
│   ├── analysis_options.yaml (<1 KB)
│   ├── main.dart (<1 KB)
│   └── pubspec.yaml (<1 KB)
├── lib
│   ├── dart
│   │   ├── 2.17.0
│   │   │   ├── all.yaml (6 KB)
│   │   │   └── recommended.yaml (1 KB)
│   ...
└── pubspec.yaml (<1 KB)
Validating package... 
Package has 0 warnings.
The server may enforce additional checks.

```
