### PR TITLE
When updating Dart lint rules, exclude Flutter lint rules from not recommended rules

### DIFF
--- a/tools/update_lint_rules/lib/src/models/lint_rule.dart
+++ b/tools/update_lint_rules/lib/src/models/lint_rule.dart
@@ -32,6 +32,10 @@ class Rule with _$Rule {
   }) = _Rule;
 
   factory Rule.fromJson(Map<String, dynamic> json) => _$RuleFromJson(json);
+
+  const Rule._();
+
+  bool get isFlutterOnly => sets.length == 1 && sets.first == RuleSet.flutter;
 }
 
 enum RuleGroup {

--- a/tools/update_lint_rules/lib/src/models/lint_rule.freezed.dart
+++ b/tools/update_lint_rules/lib/src/models/lint_rule.freezed.dart
@@ -580,7 +580,7 @@ class __$$_RuleCopyWithImpl<$Res> extends _$RuleCopyWithImpl<$Res, _$_Rule>
 
 /// @nodoc
 @JsonSerializable()
-class _$_Rule implements _Rule {
+class _$_Rule extends _Rule {
   const _$_Rule(
       {required this.name,
       required this.description,
@@ -592,7 +592,8 @@ class _$_Rule implements _Rule {
       required this.details,
       @JsonKey(name: 'sinceDartSdk') required this.since})
       : _incompatibles = incompatibles,
-        _sets = sets;
+        _sets = sets,
+        super._();
 
   factory _$_Rule.fromJson(Map<String, dynamic> json) => _$$_RuleFromJson(json);
 
@@ -681,7 +682,7 @@ class _$_Rule implements _Rule {
   }
 }
 
-abstract class _Rule implements Rule {
+abstract class _Rule extends Rule {
   const factory _Rule(
       {required final String name,
       required final String description,
@@ -692,6 +693,7 @@ abstract class _Rule implements Rule {
       required final FixStatus fixStatus,
       required final String details,
       @JsonKey(name: 'sinceDartSdk') required final Since since}) = _$_Rule;
+  const _Rule._() : super._();
 
   factory _Rule.fromJson(Map<String, dynamic> json) = _$_Rule.fromJson;
 

--- a/tools/update_lint_rules/lib/src/models/not_recommended_rule.dart
+++ b/tools/update_lint_rules/lib/src/models/not_recommended_rule.dart
@@ -3,10 +3,19 @@ import 'package:update_lint_rules/src/models/lint_rule.dart';
 
 part 'not_recommended_rule.freezed.dart';
 
+typedef NotRecommendedRules = ({
+  Iterable<NotRecommendedDartRule> dart,
+  Iterable<NotRecommendedFlutterRule> flutter,
+});
+
 @freezed
-class NotRecommendedRule with _$NotRecommendedRule {
-  const factory NotRecommendedRule({
+sealed class NotRecommendedRule with _$NotRecommendedRule {
+  const factory NotRecommendedRule.dart({
     required Rule rule,
     required String reason,
-  }) = _NotRecommendedRule;
+  }) = NotRecommendedDartRule;
+  const factory NotRecommendedRule.flutter({
+    required Rule rule,
+    required String reason,
+  }) = NotRecommendedFlutterRule;
 }

--- a/tools/update_lint_rules/lib/src/models/not_recommended_rule.freezed.dart
+++ b/tools/update_lint_rules/lib/src/models/not_recommended_rule.freezed.dart
@@ -18,6 +18,44 @@ final _privateConstructorUsedError = UnsupportedError(
 mixin _$NotRecommendedRule {
   Rule get rule => throw _privateConstructorUsedError;
   String get reason => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(Rule rule, String reason) dart,
+    required TResult Function(Rule rule, String reason) flutter,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(Rule rule, String reason)? dart,
+    TResult? Function(Rule rule, String reason)? flutter,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(Rule rule, String reason)? dart,
+    TResult Function(Rule rule, String reason)? flutter,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(NotRecommendedDartRule value) dart,
+    required TResult Function(NotRecommendedFlutterRule value) flutter,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(NotRecommendedDartRule value)? dart,
+    TResult? Function(NotRecommendedFlutterRule value)? flutter,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(NotRecommendedDartRule value)? dart,
+    TResult Function(NotRecommendedFlutterRule value)? flutter,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $NotRecommendedRuleCopyWith<NotRecommendedRule> get copyWith =>
@@ -73,11 +111,11 @@ class _$NotRecommendedRuleCopyWithImpl<$Res, $Val extends NotRecommendedRule>
 }
 
 /// @nodoc
-abstract class _$$_NotRecommendedRuleCopyWith<$Res>
+abstract class _$$NotRecommendedDartRuleCopyWith<$Res>
     implements $NotRecommendedRuleCopyWith<$Res> {
-  factory _$$_NotRecommendedRuleCopyWith(_$_NotRecommendedRule value,
-          $Res Function(_$_NotRecommendedRule) then) =
-      __$$_NotRecommendedRuleCopyWithImpl<$Res>;
+  factory _$$NotRecommendedDartRuleCopyWith(_$NotRecommendedDartRule value,
+          $Res Function(_$NotRecommendedDartRule) then) =
+      __$$NotRecommendedDartRuleCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call({Rule rule, String reason});
@@ -87,11 +125,11 @@ abstract class _$$_NotRecommendedRuleCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$_NotRecommendedRuleCopyWithImpl<$Res>
-    extends _$NotRecommendedRuleCopyWithImpl<$Res, _$_NotRecommendedRule>
-    implements _$$_NotRecommendedRuleCopyWith<$Res> {
-  __$$_NotRecommendedRuleCopyWithImpl(
-      _$_NotRecommendedRule _value, $Res Function(_$_NotRecommendedRule) _then)
+class __$$NotRecommendedDartRuleCopyWithImpl<$Res>
+    extends _$NotRecommendedRuleCopyWithImpl<$Res, _$NotRecommendedDartRule>
+    implements _$$NotRecommendedDartRuleCopyWith<$Res> {
+  __$$NotRecommendedDartRuleCopyWithImpl(_$NotRecommendedDartRule _value,
+      $Res Function(_$NotRecommendedDartRule) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -100,7 +138,7 @@ class __$$_NotRecommendedRuleCopyWithImpl<$Res>
     Object? rule = null,
     Object? reason = null,
   }) {
-    return _then(_$_NotRecommendedRule(
+    return _then(_$NotRecommendedDartRule(
       rule: null == rule
           ? _value.rule
           : rule // ignore: cast_nullable_to_non_nullable
@@ -115,8 +153,8 @@ class __$$_NotRecommendedRuleCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$_NotRecommendedRule implements _NotRecommendedRule {
-  const _$_NotRecommendedRule({required this.rule, required this.reason});
+class _$NotRecommendedDartRule implements NotRecommendedDartRule {
+  const _$NotRecommendedDartRule({required this.rule, required this.reason});
 
   @override
   final Rule rule;
@@ -125,14 +163,14 @@ class _$_NotRecommendedRule implements _NotRecommendedRule {
 
   @override
   String toString() {
-    return 'NotRecommendedRule(rule: $rule, reason: $reason)';
+    return 'NotRecommendedRule.dart(rule: $rule, reason: $reason)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_NotRecommendedRule &&
+            other is _$NotRecommendedDartRule &&
             (identical(other.rule, rule) || other.rule == rule) &&
             (identical(other.reason, reason) || other.reason == reason));
   }
@@ -143,15 +181,77 @@ class _$_NotRecommendedRule implements _NotRecommendedRule {
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$_NotRecommendedRuleCopyWith<_$_NotRecommendedRule> get copyWith =>
-      __$$_NotRecommendedRuleCopyWithImpl<_$_NotRecommendedRule>(
+  _$$NotRecommendedDartRuleCopyWith<_$NotRecommendedDartRule> get copyWith =>
+      __$$NotRecommendedDartRuleCopyWithImpl<_$NotRecommendedDartRule>(
           this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(Rule rule, String reason) dart,
+    required TResult Function(Rule rule, String reason) flutter,
+  }) {
+    return dart(rule, reason);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(Rule rule, String reason)? dart,
+    TResult? Function(Rule rule, String reason)? flutter,
+  }) {
+    return dart?.call(rule, reason);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(Rule rule, String reason)? dart,
+    TResult Function(Rule rule, String reason)? flutter,
+    required TResult orElse(),
+  }) {
+    if (dart != null) {
+      return dart(rule, reason);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(NotRecommendedDartRule value) dart,
+    required TResult Function(NotRecommendedFlutterRule value) flutter,
+  }) {
+    return dart(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(NotRecommendedDartRule value)? dart,
+    TResult? Function(NotRecommendedFlutterRule value)? flutter,
+  }) {
+    return dart?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(NotRecommendedDartRule value)? dart,
+    TResult Function(NotRecommendedFlutterRule value)? flutter,
+    required TResult orElse(),
+  }) {
+    if (dart != null) {
+      return dart(this);
+    }
+    return orElse();
+  }
 }
 
-abstract class _NotRecommendedRule implements NotRecommendedRule {
-  const factory _NotRecommendedRule(
+abstract class NotRecommendedDartRule implements NotRecommendedRule {
+  const factory NotRecommendedDartRule(
       {required final Rule rule,
-      required final String reason}) = _$_NotRecommendedRule;
+      required final String reason}) = _$NotRecommendedDartRule;
 
   @override
   Rule get rule;
@@ -159,6 +259,160 @@ abstract class _NotRecommendedRule implements NotRecommendedRule {
   String get reason;
   @override
   @JsonKey(ignore: true)
-  _$$_NotRecommendedRuleCopyWith<_$_NotRecommendedRule> get copyWith =>
+  _$$NotRecommendedDartRuleCopyWith<_$NotRecommendedDartRule> get copyWith =>
       throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$NotRecommendedFlutterRuleCopyWith<$Res>
+    implements $NotRecommendedRuleCopyWith<$Res> {
+  factory _$$NotRecommendedFlutterRuleCopyWith(
+          _$NotRecommendedFlutterRule value,
+          $Res Function(_$NotRecommendedFlutterRule) then) =
+      __$$NotRecommendedFlutterRuleCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({Rule rule, String reason});
+
+  @override
+  $RuleCopyWith<$Res> get rule;
+}
+
+/// @nodoc
+class __$$NotRecommendedFlutterRuleCopyWithImpl<$Res>
+    extends _$NotRecommendedRuleCopyWithImpl<$Res, _$NotRecommendedFlutterRule>
+    implements _$$NotRecommendedFlutterRuleCopyWith<$Res> {
+  __$$NotRecommendedFlutterRuleCopyWithImpl(_$NotRecommendedFlutterRule _value,
+      $Res Function(_$NotRecommendedFlutterRule) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? rule = null,
+    Object? reason = null,
+  }) {
+    return _then(_$NotRecommendedFlutterRule(
+      rule: null == rule
+          ? _value.rule
+          : rule // ignore: cast_nullable_to_non_nullable
+              as Rule,
+      reason: null == reason
+          ? _value.reason
+          : reason // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$NotRecommendedFlutterRule implements NotRecommendedFlutterRule {
+  const _$NotRecommendedFlutterRule({required this.rule, required this.reason});
+
+  @override
+  final Rule rule;
+  @override
+  final String reason;
+
+  @override
+  String toString() {
+    return 'NotRecommendedRule.flutter(rule: $rule, reason: $reason)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$NotRecommendedFlutterRule &&
+            (identical(other.rule, rule) || other.rule == rule) &&
+            (identical(other.reason, reason) || other.reason == reason));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, rule, reason);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$NotRecommendedFlutterRuleCopyWith<_$NotRecommendedFlutterRule>
+      get copyWith => __$$NotRecommendedFlutterRuleCopyWithImpl<
+          _$NotRecommendedFlutterRule>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(Rule rule, String reason) dart,
+    required TResult Function(Rule rule, String reason) flutter,
+  }) {
+    return flutter(rule, reason);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(Rule rule, String reason)? dart,
+    TResult? Function(Rule rule, String reason)? flutter,
+  }) {
+    return flutter?.call(rule, reason);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(Rule rule, String reason)? dart,
+    TResult Function(Rule rule, String reason)? flutter,
+    required TResult orElse(),
+  }) {
+    if (flutter != null) {
+      return flutter(rule, reason);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(NotRecommendedDartRule value) dart,
+    required TResult Function(NotRecommendedFlutterRule value) flutter,
+  }) {
+    return flutter(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(NotRecommendedDartRule value)? dart,
+    TResult? Function(NotRecommendedFlutterRule value)? flutter,
+  }) {
+    return flutter?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(NotRecommendedDartRule value)? dart,
+    TResult Function(NotRecommendedFlutterRule value)? flutter,
+    required TResult orElse(),
+  }) {
+    if (flutter != null) {
+      return flutter(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class NotRecommendedFlutterRule implements NotRecommendedRule {
+  const factory NotRecommendedFlutterRule(
+      {required final Rule rule,
+      required final String reason}) = _$NotRecommendedFlutterRule;
+
+  @override
+  Rule get rule;
+  @override
+  String get reason;
+  @override
+  @JsonKey(ignore: true)
+  _$$NotRecommendedFlutterRuleCopyWith<_$NotRecommendedFlutterRule>
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
+++ b/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
@@ -89,11 +89,12 @@ class LintRuleService {
     );
   }
 
-  Future<Iterable<NotRecommendedRule>> getNotRecommendedRules() async {
+  Future<NotRecommendedRules> getNotRecommendedRules() async {
     // TODO: Reuse what has been obtained once.
     final allRules = await getRules();
 
-    return _yumemiNotRecommendedRules.map((notRecommendedRule) {
+    final notReccomendedAllRules =
+        _yumemiNotRecommendedRules.map((notRecommendedRule) {
       final rule = allRules.firstWhereOrNull(
         (rule) => notRecommendedRule.name == rule.name,
       );
@@ -101,11 +102,18 @@ class LintRuleService {
         return null;
       }
 
-      return NotRecommendedRule(
-        rule: rule,
-        reason: notRecommendedRule.reason,
-      );
-    }).nonNulls;
+      if (rule.isFlutterOnly) {
+        return NotRecommendedRule.flutter(
+            rule: rule, reason: notRecommendedRule.reason);
+      } else {
+        return NotRecommendedRule.dart(
+            rule: rule, reason: notRecommendedRule.reason);
+      }
+    });
+    return (
+      flutter: notReccomendedAllRules.whereType<NotRecommendedFlutterRule>(),
+      dart: notReccomendedAllRules.whereType<NotRecommendedDartRule>()
+    );
   }
 
   @visibleForTesting

--- a/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
+++ b/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
@@ -76,8 +76,7 @@ class LintRuleService {
   Future<LintRules> getLintRules() async {
     final allRules = await getRules();
     final allLintRules = allRules.map((rule) {
-      if (rule.sets case final sets
-          when sets.length == 1 && sets.first == RuleSet.flutter) {
+      if (rule.isFlutterOnly) {
         return LintRule.flutter(rule);
       } else {
         return LintRule.dart(rule);

--- a/tools/update_lint_rules/lib/update_lint_rules.dart
+++ b/tools/update_lint_rules/lib/update_lint_rules.dart
@@ -56,10 +56,12 @@ Future<ExitStatus> updateLintRules(ProviderContainer container) async {
 
     final flutterSdkReleases = await sdkService.getFlutterSdkReleases();
     await analysisOptionsService.updateFlutterLintRule(
-      releases: flutterSdkReleases,
-      lintRules: lintRules.flutter,
-      notRecommendedRules: notRecommendedRules.flutter,
-    );
+        releases: flutterSdkReleases,
+        lintRules: lintRules.flutter,
+        notRecommendedRules: [
+          ...notRecommendedRules.dart,
+          ...notRecommendedRules.flutter,
+        ]);
 
     return ExitStatus.success;
   } on Exception catch (e) {

--- a/tools/update_lint_rules/lib/update_lint_rules.dart
+++ b/tools/update_lint_rules/lib/update_lint_rules.dart
@@ -51,14 +51,14 @@ Future<ExitStatus> updateLintRules(ProviderContainer container) async {
     await analysisOptionsService.updateDartLintRules(
       releases: dartSdkReleases,
       lintRules: lintRules.dart,
-      notRecommendedRules: notRecommendedRules,
+      notRecommendedRules: notRecommendedRules.dart,
     );
 
     final flutterSdkReleases = await sdkService.getFlutterSdkReleases();
     await analysisOptionsService.updateFlutterLintRule(
       releases: flutterSdkReleases,
       lintRules: lintRules.flutter,
-      notRecommendedRules: notRecommendedRules,
+      notRecommendedRules: notRecommendedRules.flutter,
     );
 
     return ExitStatus.success;

--- a/tools/update_lint_rules/test/fakes/services/fake_lint_rule_service.dart
+++ b/tools/update_lint_rules/test/fakes/services/fake_lint_rule_service.dart
@@ -9,8 +9,11 @@ class FakeLintRuleService implements LintRuleService {
   }
 
   @override
-  Future<Iterable<NotRecommendedRule>> getNotRecommendedRules() async {
-    return [];
+  Future<NotRecommendedRules> getNotRecommendedRules() async {
+    return (
+      dart: <NotRecommendedDartRule>[],
+      flutter: <NotRecommendedFlutterRule>[],
+    );
   }
 
   @override


### PR DESCRIPTION
## Issue

- close #44 

## Overview (Required)

- Add getter method isFlutterOnly to Rule class
- Changed NotRecommendedRule to union type
- Add process to exclude Flutter lint rules from the list of not recommended rules when updating Dart lint rules

