### PR TITLE
Schedule workflow to run at 9 a.m. JST every Friday

### DIFF
--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - 'main'
-  schedule:
-  # Schedule at 9 AM JST (0 AM UTC) every Friday
-  - cron: '0 0 * * 5'
 
 env:
   UPDATE_CONTRIBUTORS_BRANCH: update-contributors

--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - 'main'
+  schedule:
+  # Schedule at 9 AM JST (0 AM UTC) every Friday
+  - cron: '0 0 * * 5'
 
 env:
   UPDATE_CONTRIBUTORS_BRANCH: update-contributors

--- a/.github/workflows/update-lint-rules.yaml
+++ b/.github/workflows/update-lint-rules.yaml
@@ -1,10 +1,10 @@
 name: Update Lint Rules
 
-# TODO:
-#   Set schedule event as soon as update mechanism is implemented.
-#   https://docs.github.com/actions/using-workflows/events-that-trigger-workflows#schedule
 on:
   workflow_dispatch:
+  schedule:
+    # Schedule at 9 AM JST (0 AM UTC) every Friday
+    - cron: '0 0 * * 5'
 
 jobs:
   update:


### PR DESCRIPTION
## Issue

- close #48 

## Overview (Required)

Schedule at 9 AM JST (0 AM UTC) every Friday

## Links
https://docs.github.com/ja/actions/using-workflows/events-that-trigger-workflows#schedule