### PR TITLE
improve: Deprecate the lint rule `use_setters_to_change_properties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Examples of version updates are as follows:
 ## 2.0.0
 
 - Changed the warning level of `invalid_use_of_visible_for_testing_member` to error.
+- Changed the lint rule `use_setters_to_change_properties` to be deprecated.
 
 ## 1.6.0
 

--- a/lib/dart/2.17.0/recommended.yaml
+++ b/lib/dart/2.17.0/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/2.17.1/recommended.yaml
+++ b/lib/dart/2.17.1/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/2.17.3/recommended.yaml
+++ b/lib/dart/2.17.3/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/2.17.5/recommended.yaml
+++ b/lib/dart/2.17.5/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/2.17.6/recommended.yaml
+++ b/lib/dart/2.17.6/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/2.17.7/recommended.yaml
+++ b/lib/dart/2.17.7/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/2.18.0/recommended.yaml
+++ b/lib/dart/2.18.0/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/2.18.1/recommended.yaml
+++ b/lib/dart/2.18.1/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/2.18.2/recommended.yaml
+++ b/lib/dart/2.18.2/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/2.18.3/recommended.yaml
+++ b/lib/dart/2.18.3/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/2.18.4/recommended.yaml
+++ b/lib/dart/2.18.4/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/2.18.5/recommended.yaml
+++ b/lib/dart/2.18.5/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/2.18.6/recommended.yaml
+++ b/lib/dart/2.18.6/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/2.18.7/recommended.yaml
+++ b/lib/dart/2.18.7/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/2.19.0/recommended.yaml
+++ b/lib/dart/2.19.0/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/2.19.1/recommended.yaml
+++ b/lib/dart/2.19.1/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/2.19.2/recommended.yaml
+++ b/lib/dart/2.19.2/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/2.19.3/recommended.yaml
+++ b/lib/dart/2.19.3/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/2.19.4/recommended.yaml
+++ b/lib/dart/2.19.4/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/2.19.5/recommended.yaml
+++ b/lib/dart/2.19.5/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/2.19.6/recommended.yaml
+++ b/lib/dart/2.19.6/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.0.0/recommended.yaml
+++ b/lib/dart/3.0.0/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.0.1/recommended.yaml
+++ b/lib/dart/3.0.1/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.0.2/recommended.yaml
+++ b/lib/dart/3.0.2/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.0.3/recommended.yaml
+++ b/lib/dart/3.0.3/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.0.4/recommended.yaml
+++ b/lib/dart/3.0.4/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.0.5/recommended.yaml
+++ b/lib/dart/3.0.5/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.0.6/recommended.yaml
+++ b/lib/dart/3.0.6/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.0.7/recommended.yaml
+++ b/lib/dart/3.0.7/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.1.0/recommended.yaml
+++ b/lib/dart/3.1.0/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.1.1/recommended.yaml
+++ b/lib/dart/3.1.1/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.1.2/recommended.yaml
+++ b/lib/dart/3.1.2/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.1.3/recommended.yaml
+++ b/lib/dart/3.1.3/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.1.4/recommended.yaml
+++ b/lib/dart/3.1.4/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.1.5/recommended.yaml
+++ b/lib/dart/3.1.5/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.2.0/recommended.yaml
+++ b/lib/dart/3.2.0/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.2.1/recommended.yaml
+++ b/lib/dart/3.2.1/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.2.2/recommended.yaml
+++ b/lib/dart/3.2.2/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.2.3/recommended.yaml
+++ b/lib/dart/3.2.3/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.2.4/recommended.yaml
+++ b/lib/dart/3.2.4/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.2.5/recommended.yaml
+++ b/lib/dart/3.2.5/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/dart/3.2.6/recommended.yaml
+++ b/lib/dart/3.2.6/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.0.0/recommended.yaml
+++ b/lib/flutter/3.0.0/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.0.1/recommended.yaml
+++ b/lib/flutter/3.0.1/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.0.2/recommended.yaml
+++ b/lib/flutter/3.0.2/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.0.3/recommended.yaml
+++ b/lib/flutter/3.0.3/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.0.4/recommended.yaml
+++ b/lib/flutter/3.0.4/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.0.5/recommended.yaml
+++ b/lib/flutter/3.0.5/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.10.0/recommended.yaml
+++ b/lib/flutter/3.10.0/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.10.1/recommended.yaml
+++ b/lib/flutter/3.10.1/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.10.2/recommended.yaml
+++ b/lib/flutter/3.10.2/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.10.3/recommended.yaml
+++ b/lib/flutter/3.10.3/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.10.4/recommended.yaml
+++ b/lib/flutter/3.10.4/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.10.5/recommended.yaml
+++ b/lib/flutter/3.10.5/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.10.6/recommended.yaml
+++ b/lib/flutter/3.10.6/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.13.0/recommended.yaml
+++ b/lib/flutter/3.13.0/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.13.1/recommended.yaml
+++ b/lib/flutter/3.13.1/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.13.2/recommended.yaml
+++ b/lib/flutter/3.13.2/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.13.3/recommended.yaml
+++ b/lib/flutter/3.13.3/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.13.4/recommended.yaml
+++ b/lib/flutter/3.13.4/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.13.5/recommended.yaml
+++ b/lib/flutter/3.13.5/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.13.6/recommended.yaml
+++ b/lib/flutter/3.13.6/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.13.7/recommended.yaml
+++ b/lib/flutter/3.13.7/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.13.8/recommended.yaml
+++ b/lib/flutter/3.13.8/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.13.9/recommended.yaml
+++ b/lib/flutter/3.13.9/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.16.0/recommended.yaml
+++ b/lib/flutter/3.16.0/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.16.1/recommended.yaml
+++ b/lib/flutter/3.16.1/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.16.2/recommended.yaml
+++ b/lib/flutter/3.16.2/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.16.3/recommended.yaml
+++ b/lib/flutter/3.16.3/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.16.4/recommended.yaml
+++ b/lib/flutter/3.16.4/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.16.5/recommended.yaml
+++ b/lib/flutter/3.16.5/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.16.6/recommended.yaml
+++ b/lib/flutter/3.16.6/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.16.7/recommended.yaml
+++ b/lib/flutter/3.16.7/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.16.8/recommended.yaml
+++ b/lib/flutter/3.16.8/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.16.9/recommended.yaml
+++ b/lib/flutter/3.16.9/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.3.0/recommended.yaml
+++ b/lib/flutter/3.3.0/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.3.1/recommended.yaml
+++ b/lib/flutter/3.3.1/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.3.10/recommended.yaml
+++ b/lib/flutter/3.3.10/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.3.2/recommended.yaml
+++ b/lib/flutter/3.3.2/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.3.3/recommended.yaml
+++ b/lib/flutter/3.3.3/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.3.4/recommended.yaml
+++ b/lib/flutter/3.3.4/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.3.5/recommended.yaml
+++ b/lib/flutter/3.3.5/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.3.6/recommended.yaml
+++ b/lib/flutter/3.3.6/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.3.7/recommended.yaml
+++ b/lib/flutter/3.3.7/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.3.8/recommended.yaml
+++ b/lib/flutter/3.3.8/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.3.9/recommended.yaml
+++ b/lib/flutter/3.3.9/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.7.0/recommended.yaml
+++ b/lib/flutter/3.7.0/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.7.1/recommended.yaml
+++ b/lib/flutter/3.7.1/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.7.10/recommended.yaml
+++ b/lib/flutter/3.7.10/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.7.11/recommended.yaml
+++ b/lib/flutter/3.7.11/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.7.12/recommended.yaml
+++ b/lib/flutter/3.7.12/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.7.2/recommended.yaml
+++ b/lib/flutter/3.7.2/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.7.3/recommended.yaml
+++ b/lib/flutter/3.7.3/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.7.4/recommended.yaml
+++ b/lib/flutter/3.7.4/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.7.5/recommended.yaml
+++ b/lib/flutter/3.7.5/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.7.6/recommended.yaml
+++ b/lib/flutter/3.7.6/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.7.7/recommended.yaml
+++ b/lib/flutter/3.7.7/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.7.8/recommended.yaml
+++ b/lib/flutter/3.7.8/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/lib/flutter/3.7.9/recommended.yaml
+++ b/lib/flutter/3.7.9/recommended.yaml
@@ -51,3 +51,6 @@ linter:
 
     # Conflicts with enabling `prefer_final_locals`.
     unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
+++ b/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
@@ -65,6 +65,11 @@ const _yumemiNotRecommendedRules = <({String name, String reason})>[
     name: 'unnecessary_final',
     reason: 'Conflicts with enabling `prefer_final_locals`.',
   ),
+  (
+    name: 'use_setters_to_change_properties',
+    reason:
+        "Don't trigger warnings with methods for simple state updates, among other things.",
+  ),
 ];
 
 class LintRuleService {


### PR DESCRIPTION
## Issue

- close #90 

## Overview (Required)

Change the lint rule `use_setters_to_change_properties` to be deprecated.
