### PR TITLE
fix: Change deprecated keys to use new keys

### DIFF
--- a/.github/workflows/update-lint-rules.yaml
+++ b/.github/workflows/update-lint-rules.yaml
@@ -36,8 +36,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.APP_ID_OF_YUMEMI_PR_TOKEN_GENERATOR }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY_OF_YUMEMI_PR_TOKEN_GENERATOR }}
+          app-id: ${{ secrets.APP_ID_OF_YUMEMI_PR_TOKEN_GENERATOR }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY_OF_YUMEMI_PR_TOKEN_GENERATOR }}
 
       - name: Create a pull request
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
## Issue

- close #91 

## Overview (Required)

Changed deprecated keys to use new keys `app-id` and `private-key`.

## Links

- https://github.com/actions/create-github-app-token
