### PR TITLE
Feature/#113 improve warning level of `implementation_imports`

### DIFF
--- a/packages/yumemi_lints/CHANGELOG.md
+++ b/packages/yumemi_lints/CHANGELOG.md
@@ -24,6 +24,7 @@ Examples of version updates are as follows:
 ## 2.0.0
 
 - Changed the warning level of `invalid_use_of_visible_for_testing_member` to error.
+- Changed the warning level of `implementation_imports` to error.
 - Changed the lint rule `use_setters_to_change_properties` to be deprecated.
 - Removed the patch version from the directory name of Lint Rules.
 - Added update command to automatically update lint rules to match the Flutter or Dart sdk version of the project.

--- a/packages/yumemi_lints/lib/dart/2.17/recommended.yaml
+++ b/packages/yumemi_lints/lib/dart/2.17/recommended.yaml
@@ -16,6 +16,8 @@ analyzer:
     # of the library in which they are declared or libraries within the test
     # directory.
     invalid_use_of_visible_for_testing_member: error
+    # Files in the package's lib/src directory are not public APIs and should not be imported.
+    implementation_imports: error
 
 linter:
   rules:

--- a/packages/yumemi_lints/lib/dart/2.18/recommended.yaml
+++ b/packages/yumemi_lints/lib/dart/2.18/recommended.yaml
@@ -16,6 +16,8 @@ analyzer:
     # of the library in which they are declared or libraries within the test
     # directory.
     invalid_use_of_visible_for_testing_member: error
+    # Files in the package's lib/src directory are not public APIs and should not be imported.
+    implementation_imports: error
 
 linter:
   rules:

--- a/packages/yumemi_lints/lib/dart/2.19/recommended.yaml
+++ b/packages/yumemi_lints/lib/dart/2.19/recommended.yaml
@@ -16,6 +16,8 @@ analyzer:
     # of the library in which they are declared or libraries within the test
     # directory.
     invalid_use_of_visible_for_testing_member: error
+    # Files in the package's lib/src directory are not public APIs and should not be imported.
+    implementation_imports: error
 
 linter:
   rules:

--- a/packages/yumemi_lints/lib/dart/3.0/recommended.yaml
+++ b/packages/yumemi_lints/lib/dart/3.0/recommended.yaml
@@ -16,6 +16,8 @@ analyzer:
     # of the library in which they are declared or libraries within the test
     # directory.
     invalid_use_of_visible_for_testing_member: error
+    # Files in the package's lib/src directory are not public APIs and should not be imported.
+    implementation_imports: error
 
 linter:
   rules:

--- a/packages/yumemi_lints/lib/dart/3.1/recommended.yaml
+++ b/packages/yumemi_lints/lib/dart/3.1/recommended.yaml
@@ -16,6 +16,8 @@ analyzer:
     # of the library in which they are declared or libraries within the test
     # directory.
     invalid_use_of_visible_for_testing_member: error
+    # Files in the package's lib/src directory are not public APIs and should not be imported.
+    implementation_imports: error
 
 linter:
   rules:

--- a/packages/yumemi_lints/lib/dart/3.2/recommended.yaml
+++ b/packages/yumemi_lints/lib/dart/3.2/recommended.yaml
@@ -16,6 +16,8 @@ analyzer:
     # of the library in which they are declared or libraries within the test
     # directory.
     invalid_use_of_visible_for_testing_member: error
+    # Files in the package's lib/src directory are not public APIs and should not be imported.
+    implementation_imports: error
 
 linter:
   rules:

--- a/packages/yumemi_lints/lib/dart/3.3/recommended.yaml
+++ b/packages/yumemi_lints/lib/dart/3.3/recommended.yaml
@@ -16,6 +16,8 @@ analyzer:
     # of the library in which they are declared or libraries within the test
     # directory.
     invalid_use_of_visible_for_testing_member: error
+    # Files in the package's lib/src directory are not public APIs and should not be imported.
+    implementation_imports: error
 
 linter:
   rules:

--- a/packages/yumemi_lints/lib/flutter/3.0/recommended.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.0/recommended.yaml
@@ -16,6 +16,8 @@ analyzer:
     # of the library in which they are declared or libraries within the test
     # directory.
     invalid_use_of_visible_for_testing_member: error
+    # Files in the package's lib/src directory are not public APIs and should not be imported.
+    implementation_imports: error
 
 linter:
   rules:

--- a/packages/yumemi_lints/lib/flutter/3.10/recommended.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.10/recommended.yaml
@@ -16,6 +16,8 @@ analyzer:
     # of the library in which they are declared or libraries within the test
     # directory.
     invalid_use_of_visible_for_testing_member: error
+    # Files in the package's lib/src directory are not public APIs and should not be imported.
+    implementation_imports: error
 
 linter:
   rules:

--- a/packages/yumemi_lints/lib/flutter/3.13/recommended.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.13/recommended.yaml
@@ -16,6 +16,8 @@ analyzer:
     # of the library in which they are declared or libraries within the test
     # directory.
     invalid_use_of_visible_for_testing_member: error
+    # Files in the package's lib/src directory are not public APIs and should not be imported.
+    implementation_imports: error
 
 linter:
   rules:

--- a/packages/yumemi_lints/lib/flutter/3.16/recommended.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.16/recommended.yaml
@@ -16,6 +16,8 @@ analyzer:
     # of the library in which they are declared or libraries within the test
     # directory.
     invalid_use_of_visible_for_testing_member: error
+    # Files in the package's lib/src directory are not public APIs and should not be imported.
+    implementation_imports: error
 
 linter:
   rules:

--- a/packages/yumemi_lints/lib/flutter/3.19/recommended.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.19/recommended.yaml
@@ -16,6 +16,8 @@ analyzer:
     # of the library in which they are declared or libraries within the test
     # directory.
     invalid_use_of_visible_for_testing_member: error
+    # Files in the package's lib/src directory are not public APIs and should not be imported.
+    implementation_imports: error
 
 linter:
   rules:

--- a/packages/yumemi_lints/lib/flutter/3.3/recommended.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.3/recommended.yaml
@@ -16,6 +16,8 @@ analyzer:
     # of the library in which they are declared or libraries within the test
     # directory.
     invalid_use_of_visible_for_testing_member: error
+    # Files in the package's lib/src directory are not public APIs and should not be imported.
+    implementation_imports: error
 
 linter:
   rules:

--- a/packages/yumemi_lints/lib/flutter/3.7/recommended.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.7/recommended.yaml
@@ -16,6 +16,8 @@ analyzer:
     # of the library in which they are declared or libraries within the test
     # directory.
     invalid_use_of_visible_for_testing_member: error
+    # Files in the package's lib/src directory are not public APIs and should not be imported.
+    implementation_imports: error
 
 linter:
   rules:

--- a/tools/update_lint_rules/lib/src/services/analysis_options_service.dart
+++ b/tools/update_lint_rules/lib/src/services/analysis_options_service.dart
@@ -199,6 +199,8 @@ analyzer:
     # of the library in which they are declared or libraries within the test
     # directory.
     invalid_use_of_visible_for_testing_member: error
+    # Files in the package's lib/src directory are not public APIs and should not be imported.
+    implementation_imports: error
 ''');
 
     contentBuffer.writeln('''


### PR DESCRIPTION
## Issue

- close #113 

## Overview (Required)

- Changed the warning level of implementation_imports to error.

## Links

- https://dart.dev/tools/linter-rules/implementation_imports

