### PR TITLE
Fixed a bug in determining if a lint rule is exclusive to Flutter

### DIFF
--- a/packages/yumemi_lints/CHANGELOG.md
+++ b/packages/yumemi_lints/CHANGELOG.md
@@ -49,6 +49,18 @@ Examples of version updates are as follows:
   - `package_names`
   - `recursive_getters`
   - `void_checks`
+- Fixed a bug in determining if a lint rule is exclusive to Flutter, and added/removed some lint rules in all.yaml for dart and flutter.
+  - Added to Dart and removed from Flutter.
+    - `avoid_print`
+    - `prefer_const_constructors`
+    - `prefer_const_constructors_in_immutables`
+    - `prefer_const_declarations`
+    - `prefer_const_literals_to_create_immutables`
+  - Added to Flutter and removed from Dart.
+    - `diagnostic_describe_all_properties`
+    - `sized_box_shrink_expand`
+    - `use_colored_box`
+    - `use_decorated_box`
 
 ## 1.7.0
 

--- a/packages/yumemi_lints/analysis_options.yaml
+++ b/packages/yumemi_lints/analysis_options.yaml
@@ -1,1 +1,5 @@
 include: package:yumemi_lints/dart/2.17/recommended.yaml
+
+linter:
+  rules:
+    avoid_print: false

--- a/packages/yumemi_lints/lib/dart/2.17/all.yaml
+++ b/packages/yumemi_lints/lib/dart/2.17/all.yaml
@@ -6,6 +6,7 @@ linter:
     - always_use_package_imports # incompatibles: prefer_relative_imports
     - avoid_dynamic_calls
     - avoid_empty_else
+    - avoid_print
     - avoid_relative_lib_imports
     - avoid_slow_async_io
     - avoid_type_to_string
@@ -14,7 +15,6 @@ linter:
     - close_sinks
     - comment_references
     - control_flow_in_finally
-    - diagnostic_describe_all_properties
     - empty_statements
     - hash_and_equals
     - literal_only_boolean_expressions
@@ -109,6 +109,10 @@ linter:
     - prefer_asserts_with_message
     - prefer_collection_literals
     - prefer_conditional_assignment
+    - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
+    - prefer_const_declarations
+    - prefer_const_literals_to_create_immutables
     - prefer_constructors_over_static_methods
     - prefer_contains
     - prefer_double_quotes # incompatibles: prefer_single_quotes
@@ -141,7 +145,6 @@ linter:
     - public_member_api_docs
     - recursive_getters
     - require_trailing_commas
-    - sized_box_shrink_expand
     - slash_for_doc_comments
     - sort_constructors_first
     - sort_unnamed_constructors_first
@@ -168,8 +171,6 @@ linter:
     - unnecessary_string_escapes
     - unnecessary_string_interpolations
     - unnecessary_this
-    - use_colored_box
-    - use_decorated_box
     - use_enums
     - use_function_type_syntax_for_parameters
     - use_if_null_to_convert_nulls_to_bools

--- a/packages/yumemi_lints/lib/dart/2.18/all.yaml
+++ b/packages/yumemi_lints/lib/dart/2.18/all.yaml
@@ -6,6 +6,7 @@ linter:
     - always_use_package_imports # incompatibles: prefer_relative_imports
     - avoid_dynamic_calls
     - avoid_empty_else
+    - avoid_print
     - avoid_relative_lib_imports
     - avoid_slow_async_io
     - avoid_type_to_string
@@ -14,7 +15,6 @@ linter:
     - close_sinks
     - comment_references
     - control_flow_in_finally
-    - diagnostic_describe_all_properties
     - discarded_futures
     - empty_statements
     - hash_and_equals
@@ -110,6 +110,10 @@ linter:
     - prefer_asserts_with_message
     - prefer_collection_literals
     - prefer_conditional_assignment
+    - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
+    - prefer_const_declarations
+    - prefer_const_literals_to_create_immutables
     - prefer_constructors_over_static_methods
     - prefer_contains
     - prefer_double_quotes # incompatibles: prefer_single_quotes
@@ -142,7 +146,6 @@ linter:
     - public_member_api_docs
     - recursive_getters
     - require_trailing_commas
-    - sized_box_shrink_expand
     - slash_for_doc_comments
     - sort_constructors_first
     - sort_unnamed_constructors_first
@@ -171,8 +174,6 @@ linter:
     - unnecessary_string_interpolations
     - unnecessary_this
     - unnecessary_to_list_in_spreads
-    - use_colored_box
-    - use_decorated_box
     - use_enums
     - use_function_type_syntax_for_parameters
     - use_if_null_to_convert_nulls_to_bools

--- a/packages/yumemi_lints/lib/dart/2.19/all.yaml
+++ b/packages/yumemi_lints/lib/dart/2.19/all.yaml
@@ -6,6 +6,7 @@ linter:
     - always_use_package_imports # incompatibles: prefer_relative_imports
     - avoid_dynamic_calls
     - avoid_empty_else
+    - avoid_print
     - avoid_relative_lib_imports
     - avoid_slow_async_io
     - avoid_type_to_string
@@ -15,7 +16,6 @@ linter:
     - collection_methods_unrelated_type
     - comment_references
     - control_flow_in_finally
-    - diagnostic_describe_all_properties
     - discarded_futures
     - empty_statements
     - hash_and_equals
@@ -115,6 +115,10 @@ linter:
     - prefer_asserts_with_message
     - prefer_collection_literals
     - prefer_conditional_assignment
+    - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
+    - prefer_const_declarations
+    - prefer_const_literals_to_create_immutables
     - prefer_constructors_over_static_methods
     - prefer_contains
     - prefer_double_quotes # incompatibles: prefer_single_quotes
@@ -147,7 +151,6 @@ linter:
     - public_member_api_docs
     - recursive_getters
     - require_trailing_commas
-    - sized_box_shrink_expand
     - slash_for_doc_comments
     - sort_constructors_first
     - sort_unnamed_constructors_first
@@ -178,8 +181,6 @@ linter:
     - unnecessary_this
     - unnecessary_to_list_in_spreads
     - unreachable_from_main
-    - use_colored_box
-    - use_decorated_box
     - use_enums
     - use_function_type_syntax_for_parameters
     - use_if_null_to_convert_nulls_to_bools

--- a/packages/yumemi_lints/lib/dart/3.0/all.yaml
+++ b/packages/yumemi_lints/lib/dart/3.0/all.yaml
@@ -6,6 +6,7 @@ linter:
     - always_use_package_imports # incompatibles: prefer_relative_imports
     - avoid_dynamic_calls
     - avoid_empty_else
+    - avoid_print
     - avoid_relative_lib_imports
     - avoid_slow_async_io
     - avoid_type_to_string
@@ -16,7 +17,6 @@ linter:
     - comment_references
     - control_flow_in_finally
     - deprecated_member_use_from_same_package
-    - diagnostic_describe_all_properties
     - discarded_futures
     - empty_statements
     - hash_and_equals
@@ -120,6 +120,10 @@ linter:
     - prefer_asserts_with_message
     - prefer_collection_literals
     - prefer_conditional_assignment
+    - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
+    - prefer_const_declarations
+    - prefer_const_literals_to_create_immutables
     - prefer_constructors_over_static_methods
     - prefer_contains
     - prefer_double_quotes # incompatibles: prefer_single_quotes
@@ -152,7 +156,6 @@ linter:
     - public_member_api_docs
     - recursive_getters
     - require_trailing_commas
-    - sized_box_shrink_expand
     - slash_for_doc_comments
     - sort_constructors_first
     - sort_unnamed_constructors_first
@@ -185,8 +188,6 @@ linter:
     - unnecessary_this
     - unnecessary_to_list_in_spreads
     - unreachable_from_main
-    - use_colored_box
-    - use_decorated_box
     - use_enums
     - use_function_type_syntax_for_parameters
     - use_if_null_to_convert_nulls_to_bools

--- a/packages/yumemi_lints/lib/dart/3.1/all.yaml
+++ b/packages/yumemi_lints/lib/dart/3.1/all.yaml
@@ -6,6 +6,7 @@ linter:
     - always_use_package_imports # incompatibles: prefer_relative_imports
     - avoid_dynamic_calls
     - avoid_empty_else
+    - avoid_print
     - avoid_relative_lib_imports
     - avoid_slow_async_io
     - avoid_type_to_string
@@ -16,7 +17,6 @@ linter:
     - comment_references
     - control_flow_in_finally
     - deprecated_member_use_from_same_package
-    - diagnostic_describe_all_properties
     - discarded_futures
     - empty_statements
     - hash_and_equals
@@ -122,6 +122,10 @@ linter:
     - prefer_asserts_with_message
     - prefer_collection_literals
     - prefer_conditional_assignment
+    - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
+    - prefer_const_declarations
+    - prefer_const_literals_to_create_immutables
     - prefer_constructors_over_static_methods
     - prefer_contains
     - prefer_double_quotes # incompatibles: prefer_single_quotes
@@ -154,7 +158,6 @@ linter:
     - public_member_api_docs
     - recursive_getters
     - require_trailing_commas
-    - sized_box_shrink_expand
     - slash_for_doc_comments
     - sort_constructors_first
     - sort_unnamed_constructors_first
@@ -187,8 +190,6 @@ linter:
     - unnecessary_this
     - unnecessary_to_list_in_spreads
     - unreachable_from_main
-    - use_colored_box
-    - use_decorated_box
     - use_enums
     - use_function_type_syntax_for_parameters
     - use_if_null_to_convert_nulls_to_bools

--- a/packages/yumemi_lints/lib/dart/3.2/all.yaml
+++ b/packages/yumemi_lints/lib/dart/3.2/all.yaml
@@ -6,6 +6,7 @@ linter:
     - always_use_package_imports # incompatibles: prefer_relative_imports
     - avoid_dynamic_calls
     - avoid_empty_else
+    - avoid_print
     - avoid_relative_lib_imports
     - avoid_slow_async_io
     - avoid_type_to_string
@@ -16,7 +17,6 @@ linter:
     - comment_references
     - control_flow_in_finally
     - deprecated_member_use_from_same_package
-    - diagnostic_describe_all_properties
     - discarded_futures
     - empty_statements
     - hash_and_equals
@@ -123,6 +123,10 @@ linter:
     - prefer_asserts_with_message
     - prefer_collection_literals
     - prefer_conditional_assignment
+    - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
+    - prefer_const_declarations
+    - prefer_const_literals_to_create_immutables
     - prefer_constructors_over_static_methods
     - prefer_contains
     - prefer_double_quotes # incompatibles: prefer_single_quotes
@@ -155,7 +159,6 @@ linter:
     - public_member_api_docs
     - recursive_getters
     - require_trailing_commas
-    - sized_box_shrink_expand
     - slash_for_doc_comments
     - sort_constructors_first
     - sort_unnamed_constructors_first
@@ -188,8 +191,6 @@ linter:
     - unnecessary_this
     - unnecessary_to_list_in_spreads
     - unreachable_from_main
-    - use_colored_box
-    - use_decorated_box
     - use_enums
     - use_function_type_syntax_for_parameters
     - use_if_null_to_convert_nulls_to_bools

--- a/packages/yumemi_lints/lib/dart/3.3/all.yaml
+++ b/packages/yumemi_lints/lib/dart/3.3/all.yaml
@@ -6,6 +6,7 @@ linter:
     - always_use_package_imports # incompatibles: prefer_relative_imports
     - avoid_dynamic_calls
     - avoid_empty_else
+    - avoid_print
     - avoid_relative_lib_imports
     - avoid_slow_async_io
     - avoid_type_to_string
@@ -16,7 +17,6 @@ linter:
     - comment_references
     - control_flow_in_finally
     - deprecated_member_use_from_same_package
-    - diagnostic_describe_all_properties
     - discarded_futures
     - empty_statements
     - hash_and_equals
@@ -123,6 +123,10 @@ linter:
     - prefer_asserts_with_message
     - prefer_collection_literals
     - prefer_conditional_assignment
+    - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
+    - prefer_const_declarations
+    - prefer_const_literals_to_create_immutables
     - prefer_constructors_over_static_methods
     - prefer_contains
     - prefer_double_quotes # incompatibles: prefer_single_quotes
@@ -155,7 +159,6 @@ linter:
     - public_member_api_docs
     - recursive_getters
     - require_trailing_commas
-    - sized_box_shrink_expand
     - slash_for_doc_comments
     - sort_constructors_first
     - sort_unnamed_constructors_first
@@ -188,8 +191,6 @@ linter:
     - unnecessary_this
     - unnecessary_to_list_in_spreads
     - unreachable_from_main
-    - use_colored_box
-    - use_decorated_box
     - use_enums
     - use_function_type_syntax_for_parameters
     - use_if_null_to_convert_nulls_to_bools

--- a/packages/yumemi_lints/lib/flutter/3.0/all.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.0/all.yaml
@@ -5,18 +5,17 @@ include: package:yumemi_lints/dart/2.17/all.yaml
 linter:
   rules:
     # Errors
-    - avoid_print
     - avoid_web_libraries_in_flutter
+    - diagnostic_describe_all_properties
     - no_logic_in_create_state
     - use_build_context_synchronously
     - use_key_in_widget_constructors
 
     # Style
     - avoid_unnecessary_containers
-    - prefer_const_constructors
-    - prefer_const_constructors_in_immutables
-    - prefer_const_declarations
-    - prefer_const_literals_to_create_immutables
     - sized_box_for_whitespace
+    - sized_box_shrink_expand
     - sort_child_properties_last
+    - use_colored_box
+    - use_decorated_box
     - use_full_hex_values_for_flutter_colors

--- a/packages/yumemi_lints/lib/flutter/3.10/all.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.10/all.yaml
@@ -5,18 +5,17 @@ include: package:yumemi_lints/dart/3.0/all.yaml
 linter:
   rules:
     # Errors
-    - avoid_print
     - avoid_web_libraries_in_flutter
+    - diagnostic_describe_all_properties
     - no_logic_in_create_state
     - use_build_context_synchronously
     - use_key_in_widget_constructors
 
     # Style
     - avoid_unnecessary_containers
-    - prefer_const_constructors
-    - prefer_const_constructors_in_immutables
-    - prefer_const_declarations
-    - prefer_const_literals_to_create_immutables
     - sized_box_for_whitespace
+    - sized_box_shrink_expand
     - sort_child_properties_last
+    - use_colored_box
+    - use_decorated_box
     - use_full_hex_values_for_flutter_colors

--- a/packages/yumemi_lints/lib/flutter/3.13/all.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.13/all.yaml
@@ -5,18 +5,17 @@ include: package:yumemi_lints/dart/3.1/all.yaml
 linter:
   rules:
     # Errors
-    - avoid_print
     - avoid_web_libraries_in_flutter
+    - diagnostic_describe_all_properties
     - no_logic_in_create_state
     - use_build_context_synchronously
     - use_key_in_widget_constructors
 
     # Style
     - avoid_unnecessary_containers
-    - prefer_const_constructors
-    - prefer_const_constructors_in_immutables
-    - prefer_const_declarations
-    - prefer_const_literals_to_create_immutables
     - sized_box_for_whitespace
+    - sized_box_shrink_expand
     - sort_child_properties_last
+    - use_colored_box
+    - use_decorated_box
     - use_full_hex_values_for_flutter_colors

--- a/packages/yumemi_lints/lib/flutter/3.16/all.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.16/all.yaml
@@ -5,18 +5,17 @@ include: package:yumemi_lints/dart/3.2/all.yaml
 linter:
   rules:
     # Errors
-    - avoid_print
     - avoid_web_libraries_in_flutter
+    - diagnostic_describe_all_properties
     - no_logic_in_create_state
     - use_build_context_synchronously
     - use_key_in_widget_constructors
 
     # Style
     - avoid_unnecessary_containers
-    - prefer_const_constructors
-    - prefer_const_constructors_in_immutables
-    - prefer_const_declarations
-    - prefer_const_literals_to_create_immutables
     - sized_box_for_whitespace
+    - sized_box_shrink_expand
     - sort_child_properties_last
+    - use_colored_box
+    - use_decorated_box
     - use_full_hex_values_for_flutter_colors

--- a/packages/yumemi_lints/lib/flutter/3.19/all.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.19/all.yaml
@@ -5,18 +5,17 @@ include: package:yumemi_lints/dart/3.3/all.yaml
 linter:
   rules:
     # Errors
-    - avoid_print
     - avoid_web_libraries_in_flutter
+    - diagnostic_describe_all_properties
     - no_logic_in_create_state
     - use_build_context_synchronously
     - use_key_in_widget_constructors
 
     # Style
     - avoid_unnecessary_containers
-    - prefer_const_constructors
-    - prefer_const_constructors_in_immutables
-    - prefer_const_declarations
-    - prefer_const_literals_to_create_immutables
     - sized_box_for_whitespace
+    - sized_box_shrink_expand
     - sort_child_properties_last
+    - use_colored_box
+    - use_decorated_box
     - use_full_hex_values_for_flutter_colors

--- a/packages/yumemi_lints/lib/flutter/3.3/all.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.3/all.yaml
@@ -5,18 +5,17 @@ include: package:yumemi_lints/dart/2.18/all.yaml
 linter:
   rules:
     # Errors
-    - avoid_print
     - avoid_web_libraries_in_flutter
+    - diagnostic_describe_all_properties
     - no_logic_in_create_state
     - use_build_context_synchronously
     - use_key_in_widget_constructors
 
     # Style
     - avoid_unnecessary_containers
-    - prefer_const_constructors
-    - prefer_const_constructors_in_immutables
-    - prefer_const_declarations
-    - prefer_const_literals_to_create_immutables
     - sized_box_for_whitespace
+    - sized_box_shrink_expand
     - sort_child_properties_last
+    - use_colored_box
+    - use_decorated_box
     - use_full_hex_values_for_flutter_colors

--- a/packages/yumemi_lints/lib/flutter/3.7/all.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.7/all.yaml
@@ -5,18 +5,17 @@ include: package:yumemi_lints/dart/2.19/all.yaml
 linter:
   rules:
     # Errors
-    - avoid_print
     - avoid_web_libraries_in_flutter
+    - diagnostic_describe_all_properties
     - no_logic_in_create_state
     - use_build_context_synchronously
     - use_key_in_widget_constructors
 
     # Style
     - avoid_unnecessary_containers
-    - prefer_const_constructors
-    - prefer_const_constructors_in_immutables
-    - prefer_const_declarations
-    - prefer_const_literals_to_create_immutables
     - sized_box_for_whitespace
+    - sized_box_shrink_expand
     - sort_child_properties_last
+    - use_colored_box
+    - use_decorated_box
     - use_full_hex_values_for_flutter_colors

--- a/packages/yumemi_lints/lib/src/command_services/update_command_service.dart
+++ b/packages/yumemi_lints/lib/src/command_services/update_command_service.dart
@@ -79,7 +79,7 @@ class UpdateCommandService {
     final flutterVersion = (yaml['environment'] as YamlMap)['flutter'];
 
     if (flutterVersion == null) {
-      throw FormatException(
+      throw const FormatException(
         'Please put [flutter: Flutter Version] '
         'under the environment section in pubspec.yaml',
       );
@@ -94,7 +94,7 @@ class UpdateCommandService {
     final dartVersion = (yaml['environment'] as YamlMap)['sdk'];
 
     if (dartVersion == null) {
-      throw FormatException(
+      throw const FormatException(
         'Please put [sdk: Dart Version] '
         'under the environment section in pubspec.yaml',
       );
@@ -106,7 +106,7 @@ class UpdateCommandService {
   @visibleForTesting
   Version extractVersion(String versionString) {
     if (versionString.contains('<') && !versionString.contains('>=')) {
-      throw FormatException('Please specify the minimum version.');
+      throw const FormatException('Please specify the minimum version.');
     }
 
     RegExp regExp;
@@ -118,7 +118,7 @@ class UpdateCommandService {
     final match = regExp.firstMatch(versionString);
 
     if (match == null) {
-      throw FormatException(
+      throw const FormatException(
         'The version of Dart or Flutter could not be found in pubspec.yaml. '
         'Please ensure that '
         'the version is correctly specified for Dart or Flutter.',

--- a/tools/update_lint_rules/lib/src/models/lint_rule.dart
+++ b/tools/update_lint_rules/lib/src/models/lint_rule.dart
@@ -34,8 +34,6 @@ class Rule with _$Rule {
   factory Rule.fromJson(Map<String, dynamic> json) => _$RuleFromJson(json);
 
   const Rule._();
-
-  bool get isFlutterOnly => sets.length == 1 && sets.first == RuleSet.flutter;
 }
 
 enum RuleGroup {

--- a/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
+++ b/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:async/async.dart';
 import 'package:collection/collection.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:http/http.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:update_lint_rules/src/clients/app_client.dart';
 import 'package:update_lint_rules/src/models/lint_rule.dart';
@@ -128,6 +129,20 @@ class LintRuleService {
           return rules;
         },
       );
+
+  Future<bool> isFlutterOnlyRule(Rule rule) async {
+    final url = Uri.https(
+      'raw.githubusercontent.com',
+      'dart-lang/sdk/main/pkg/linter/lib/src/rules/${rule.name}.dart',
+    );
+
+    try {
+      final responseBody = await _appClient.read(url);
+      return responseBody.contains('flutter');
+    } on ClientException {
+      return false;
+    }
+  }
 }
 
 typedef _NotRecommendedRule = ({

--- a/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
+++ b/tools/update_lint_rules/lib/src/services/lint_rule_service.dart
@@ -140,6 +140,10 @@ class LintRuleService {
       );
 
   Future<bool> isFlutterOnlyRule(Rule rule) async {
+    if (_isNotFlutterOnlyRules.contains(rule.name)) {
+      return false;
+    }
+
     final url = Uri.https(
       'raw.githubusercontent.com',
       'dart-lang/sdk/main/pkg/linter/lib/src/rules/${rule.name}.dart',
@@ -153,6 +157,17 @@ class LintRuleService {
     }
   }
 }
+
+/// NOTE:
+///   The current implementation of `isFlutterOnlyRule()` cannot accurately
+///   determine if a rule is a Flutter-only rule, so as a workaround, it keeps
+///   a list of rule names that cannot be accurately determined.
+const _isNotFlutterOnlyRules = [
+  'avoid_print',
+  'always_put_control_body_on_new_line',
+  'always_specify_types',
+  'flutter_style_todos',
+];
 
 typedef _NotRecommendedRule = ({
   String name,

--- a/tools/update_lint_rules/test/fakes/services/fake_lint_rule_service.dart
+++ b/tools/update_lint_rules/test/fakes/services/fake_lint_rule_service.dart
@@ -29,4 +29,9 @@ class FakeLintRuleService implements LintRuleService {
   Future<Iterable<Rule>> getRules() async {
     return [];
   }
+
+  @override
+  Future<bool> isFlutterOnlyRule(Rule rule) async {
+    return false;
+  }
 }


### PR DESCRIPTION
## Issue

- close #121 

## Overview (Required)

Fixed a bug in determining if a lint rule is exclusive to Flutter, and added/removed some lint rules in all.yaml for dart and flutter.

See 31185135047017bd5bd3968676a6693c42997d19 for the difference in all.yaml.

## Links

N/A

## Screenshot

N/A