### PR TITLE
Update package version to 2.2.0

### DIFF
--- a/packages/yumemi_lints/CHANGELOG.md
+++ b/packages/yumemi_lints/CHANGELOG.md
@@ -21,6 +21,12 @@ Examples of version updates are as follows:
 > [!NOTE]
 > Changes to `tools/update_lint_rules` don't affect versioning.
 
+## 2.2.0
+
+### Improvements
+
+- Output to use "categories" instead of "group".
+
 ## 2.1.0
 
 - Added support for Dart 3.4.x.

--- a/packages/yumemi_lints/CHANGELOG.md
+++ b/packages/yumemi_lints/CHANGELOG.md
@@ -23,6 +23,11 @@ Examples of version updates are as follows:
 
 ## 2.2.0
 
+### Features
+
+- Added support for Dart 3.5.x.
+- Added support for Flutter 3.24.x.
+
 ### Improvements
 
 - Output to use "categories" instead of "group".

--- a/packages/yumemi_lints/lib/dart/2.17/all.yaml
+++ b/packages/yumemi_lints/lib/dart/2.17/all.yaml
@@ -2,192 +2,187 @@
 
 linter:
   rules:
-    # Errors
-    - always_use_package_imports # incompatibles: prefer_relative_imports
-    - avoid_dynamic_calls
-    - avoid_empty_else
-    - avoid_print
-    - avoid_relative_lib_imports
-    - avoid_slow_async_io
-    - avoid_type_to_string
-    - avoid_types_as_parameter_names
-    - cancel_subscriptions
-    - close_sinks
-    - comment_references
-    - control_flow_in_finally
-    - empty_statements
-    - hash_and_equals
-    - literal_only_boolean_expressions
-    - no_adjacent_strings_in_list
-    - no_duplicate_case_values
-    - prefer_relative_imports # incompatibles: always_use_package_imports
-    - prefer_void_to_null
-    - test_types_in_equals
-    - throw_in_finally
-    - unnecessary_statements
-    - unrelated_type_equality_checks
-    - unsafe_html
-    - valid_regexps
-
-    # Style
-    - always_declare_return_types
-    - always_put_control_body_on_new_line
-    - always_put_required_named_parameters_first
-    - always_specify_types # incompatibles: avoid_types_on_closure_parameters,omit_local_variable_types
-    - annotate_overrides
-    - avoid_annotating_with_dynamic
-    - avoid_bool_literals_in_conditional_expressions
-    - avoid_catches_without_on_clauses
-    - avoid_catching_errors
-    - avoid_classes_with_only_static_members
-    - avoid_double_and_int_checks
-    - avoid_equals_and_hash_code_on_mutable_classes
-    - avoid_escaping_inner_quotes
-    - avoid_field_initializers_in_const_classes
-    - avoid_final_parameters # incompatibles: prefer_final_parameters
-    - avoid_function_literals_in_foreach_calls
-    - avoid_implementing_value_types
-    - avoid_init_to_null
-    - avoid_js_rounded_ints
-    - avoid_multiple_declarations_per_line
-    - avoid_null_checks_in_equality_operators
-    - avoid_positional_boolean_parameters
-    - avoid_private_typedef_functions
-    - avoid_redundant_argument_values
-    - avoid_renaming_method_parameters
-    - avoid_return_types_on_setters
-    - avoid_returning_null_for_void
-    - avoid_returning_this
-    - avoid_setters_without_getters
-    - avoid_shadowing_type_parameters
-    - avoid_single_cascade_in_expression_statements
-    - avoid_types_on_closure_parameters # incompatibles: always_specify_types
-    - avoid_unused_constructor_parameters
-    - avoid_void_async
-    - await_only_futures
-    - camel_case_extensions
-    - camel_case_types
-    - cascade_invocations
-    - cast_nullable_to_non_nullable
-    - conditional_uri_does_not_exist
-    - constant_identifier_names
-    - curly_braces_in_flow_control_structures
-    - deprecated_consistency
-    - directives_ordering
-    - do_not_use_environment
-    - empty_catches
-    - empty_constructor_bodies
-    - eol_at_end_of_file
-    - exhaustive_cases
-    - file_names
-    - flutter_style_todos
-    - implementation_imports
-    - join_return_with_assignment
-    - leading_newlines_in_multiline_strings
-    - library_names
-    - library_prefixes
-    - library_private_types_in_public_api
-    - lines_longer_than_80_chars
-    - missing_whitespace_between_adjacent_strings
-    - no_default_cases
-    - no_leading_underscores_for_library_prefixes
-    - no_leading_underscores_for_local_identifiers
-    - no_runtimeType_toString
-    - non_constant_identifier_names
-    - noop_primitive_operations
-    - null_check_on_nullable_type_parameter
-    - null_closures
-    - omit_local_variable_types # incompatibles: always_specify_types
-    - one_member_abstracts
-    - only_throw_errors
-    - overridden_fields
-    - package_api_docs
-    - package_prefixed_library_names
-    - parameter_assignments
-    - prefer_adjacent_string_concatenation
-    - prefer_asserts_in_initializer_lists
-    - prefer_asserts_with_message
-    - prefer_collection_literals
-    - prefer_conditional_assignment
-    - prefer_const_constructors
-    - prefer_const_constructors_in_immutables
-    - prefer_const_declarations
-    - prefer_const_literals_to_create_immutables
-    - prefer_constructors_over_static_methods
-    - prefer_contains
-    - prefer_double_quotes # incompatibles: prefer_single_quotes
-    - prefer_expression_function_bodies
-    - prefer_final_fields
-    - prefer_final_in_for_each
-    - prefer_final_locals # incompatibles: unnecessary_final
-    - prefer_final_parameters # incompatibles: unnecessary_final,avoid_final_parameters
-    - prefer_for_elements_to_map_fromIterable
-    - prefer_foreach
-    - prefer_function_declarations_over_variables
-    - prefer_generic_function_type_aliases
-    - prefer_if_elements_to_conditional_expressions
-    - prefer_if_null_operators
-    - prefer_initializing_formals
-    - prefer_inlined_adds
-    - prefer_int_literals
-    - prefer_interpolation_to_compose_strings
-    - prefer_is_empty
-    - prefer_is_not_empty
-    - prefer_is_not_operator
-    - prefer_iterable_whereType
-    - prefer_mixin
-    - prefer_null_aware_method_calls
-    - prefer_null_aware_operators
-    - prefer_single_quotes # incompatibles: prefer_double_quotes
-    - prefer_spread_collections
-    - prefer_typing_uninitialized_variables
-    - provide_deprecation_message
-    - public_member_api_docs
-    - recursive_getters
-    - require_trailing_commas
-    - slash_for_doc_comments
-    - sort_constructors_first
-    - sort_unnamed_constructors_first
-    - tighten_type_of_initializing_formals
-    - type_annotate_public_apis
-    - type_init_formals
-    - unawaited_futures
-    - unnecessary_await_in_return
-    - unnecessary_brace_in_string_interps
-    - unnecessary_const
-    - unnecessary_constructor_name
-    - unnecessary_final # incompatibles: prefer_final_locals,prefer_final_parameters
-    - unnecessary_getters_setters
-    - unnecessary_lambdas
-    - unnecessary_late
-    - unnecessary_new
-    - unnecessary_null_aware_assignments
-    - unnecessary_null_checks
-    - unnecessary_null_in_if_null_operators
-    - unnecessary_nullable_for_final_variable_declarations
-    - unnecessary_overrides
-    - unnecessary_parenthesis
-    - unnecessary_raw_strings
-    - unnecessary_string_escapes
-    - unnecessary_string_interpolations
-    - unnecessary_this
-    - use_enums
-    - use_function_type_syntax_for_parameters
-    - use_if_null_to_convert_nulls_to_bools
-    - use_is_even_rather_than_modulo
-    - use_late_for_private_fields_and_variables
-    - use_named_constants
-    - use_raw_strings
-    - use_rethrow_when_possible
-    - use_setters_to_change_properties
-    - use_string_buffers
-    - use_super_parameters
-    - use_test_throws_matchers
-    - use_to_and_as_if_applicable
-    - void_checks
-
-    # Pub
-    - depend_on_referenced_packages
-    - package_names
-    - secure_pubspec_urls
-    - sort_pub_dependencies
+    - always_declare_return_types # categories: style
+    - always_put_control_body_on_new_line # categories: style
+    - always_put_required_named_parameters_first # categories: style
+    - always_specify_types # incompatibles: avoid_types_on_closure_parameters,omit_local_variable_types,omit_obvious_local_variable_types # categories: style
+    - always_use_package_imports # incompatibles: prefer_relative_imports # categories: error-prone
+    - annotate_overrides # categories: style
+    - avoid_annotating_with_dynamic # categories: brevity,style
+    - avoid_bool_literals_in_conditional_expressions # categories: brevity
+    - avoid_catches_without_on_clauses # categories: effective dart,style
+    - avoid_catching_errors # categories: style
+    - avoid_classes_with_only_static_members # categories: effective dart,language feature usage,style
+    - avoid_double_and_int_checks # categories: error-prone,web
+    - avoid_dynamic_calls # categories: binary size,error-prone
+    - avoid_empty_else # categories: brevity,error-prone
+    - avoid_equals_and_hash_code_on_mutable_classes # categories: effective dart,style
+    - avoid_escaping_inner_quotes # categories: style
+    - avoid_field_initializers_in_const_classes # categories: style
+    - avoid_final_parameters # incompatibles: prefer_final_parameters # categories: style
+    - avoid_function_literals_in_foreach_calls # categories: style
+    - avoid_implementing_value_types # categories: style
+    - avoid_init_to_null # categories: brevity,effective dart,style
+    - avoid_js_rounded_ints # categories: error-prone,web
+    - avoid_multiple_declarations_per_line # categories: style
+    - avoid_null_checks_in_equality_operators # categories: style
+    - avoid_positional_boolean_parameters # categories: effective dart,style
+    - avoid_print # categories: unintentional
+    - avoid_private_typedef_functions # categories: style
+    - avoid_redundant_argument_values # categories: brevity,style
+    - avoid_relative_lib_imports # categories: error-prone
+    - avoid_renaming_method_parameters # categories: documentation comment maintenance
+    - avoid_return_types_on_setters # categories: brevity,style
+    - avoid_returning_null_for_void # categories: style
+    - avoid_returning_this # categories: effective dart,style
+    - avoid_setters_without_getters # categories: style
+    - avoid_shadowing_type_parameters # categories: error-prone
+    - avoid_single_cascade_in_expression_statements # categories: brevity,style
+    - avoid_slow_async_io # categories: non-performant
+    - avoid_type_to_string # categories: unintentional
+    - avoid_types_as_parameter_names # categories: unintentional
+    - avoid_types_on_closure_parameters # incompatibles: always_specify_types # categories: style
+    - avoid_unused_constructor_parameters # categories: unintentional
+    - avoid_void_async # categories: style
+    - await_only_futures # categories: style
+    - camel_case_extensions # categories: effective dart,style
+    - camel_case_types # categories: effective dart,style
+    - cancel_subscriptions # categories: error-prone,memory leaks
+    - cascade_invocations # categories: brevity,language feature usage,style
+    - cast_nullable_to_non_nullable # categories: error-prone
+    - close_sinks # categories: error-prone,memory leaks
+    - comment_references # categories: documentation comment maintenance
+    - conditional_uri_does_not_exist # categories: error-prone
+    - constant_identifier_names # categories: style
+    - control_flow_in_finally # categories: error-prone
+    - curly_braces_in_flow_control_structures # categories: error-prone
+    - depend_on_referenced_packages # categories: pub
+    - deprecated_consistency # categories: style
+    - directives_ordering # categories: style
+    - do_not_use_environment # categories: error-prone
+    - empty_catches # categories: style
+    - empty_constructor_bodies # categories: brevity,effective dart,style
+    - empty_statements # categories: error-prone
+    - eol_at_end_of_file # categories: style
+    - exhaustive_cases # categories: error-prone
+    - file_names # categories: style
+    - flutter_style_todos # categories: style
+    - hash_and_equals # categories: error-prone
+    - implementation_imports # categories: style
+    - join_return_with_assignment # categories: brevity,style
+    - leading_newlines_in_multiline_strings # categories: style
+    - library_names # categories: style
+    - library_prefixes # categories: style
+    - library_private_types_in_public_api # categories: public interface
+    - lines_longer_than_80_chars # categories: style
+    - literal_only_boolean_expressions # categories: unused code
+    - missing_whitespace_between_adjacent_strings # categories: error-prone
+    - no_adjacent_strings_in_list # categories: style
+    - no_default_cases # categories: style
+    - no_duplicate_case_values # categories: error-prone
+    - no_leading_underscores_for_library_prefixes # categories: style
+    - no_leading_underscores_for_local_identifiers # categories: style
+    - no_runtimeType_toString # categories: non-performant
+    - non_constant_identifier_names # categories: style
+    - noop_primitive_operations # categories: style
+    - null_check_on_nullable_type_parameter # categories: style
+    - null_closures # categories: error-prone
+    - omit_local_variable_types # incompatibles: always_specify_types # categories: style
+    - one_member_abstracts # categories: effective dart,language feature usage,style
+    - only_throw_errors # categories: style
+    - overridden_fields # categories: style
+    - package_api_docs # categories: effective dart,public interface
+    - package_names # categories: style
+    - package_prefixed_library_names # categories: style
+    - parameter_assignments # categories: style
+    - prefer_adjacent_string_concatenation # categories: style
+    - prefer_asserts_in_initializer_lists # categories: style
+    - prefer_asserts_with_message # categories: style
+    - prefer_collection_literals # categories: brevity,style
+    - prefer_conditional_assignment # categories: brevity,style
+    - prefer_const_constructors # categories: style
+    - prefer_const_constructors_in_immutables # categories: style
+    - prefer_const_declarations # categories: style
+    - prefer_const_literals_to_create_immutables # categories: style
+    - prefer_constructors_over_static_methods # categories: style
+    - prefer_contains # categories: style
+    - prefer_double_quotes # incompatibles: prefer_single_quotes # categories: style
+    - prefer_expression_function_bodies # categories: brevity,style
+    - prefer_final_fields # categories: effective dart,style
+    - prefer_final_in_for_each # categories: style
+    - prefer_final_locals # incompatibles: unnecessary_final # categories: style
+    - prefer_final_parameters # incompatibles: unnecessary_final,avoid_final_parameters # categories: style
+    - prefer_for_elements_to_map_fromIterable # categories: brevity,style
+    - prefer_foreach # categories: style
+    - prefer_function_declarations_over_variables # categories: effective dart,style
+    - prefer_generic_function_type_aliases # categories: style
+    - prefer_if_elements_to_conditional_expressions # categories: brevity,style
+    - prefer_if_null_operators # categories: brevity,style
+    - prefer_initializing_formals # categories: brevity,style
+    - prefer_inlined_adds # categories: brevity,style
+    - prefer_int_literals # categories: style
+    - prefer_interpolation_to_compose_strings # categories: style
+    - prefer_is_empty # categories: style
+    - prefer_is_not_empty # categories: style
+    - prefer_is_not_operator # categories: brevity,style
+    - prefer_iterable_whereType # categories: style
+    - prefer_mixin # categories: language feature usage,style
+    - prefer_null_aware_method_calls # categories: brevity,style
+    - prefer_null_aware_operators # categories: brevity,style
+    - prefer_relative_imports # incompatibles: always_use_package_imports # categories: error-prone
+    - prefer_single_quotes # incompatibles: prefer_double_quotes # categories: style
+    - prefer_spread_collections # categories: brevity,style
+    - prefer_typing_uninitialized_variables # categories: error-prone,unintentional
+    - prefer_void_to_null # categories: error-prone
+    - provide_deprecation_message # categories: public interface
+    - public_member_api_docs # categories: public interface,style
+    - recursive_getters # categories: error-prone,unintentional
+    - require_trailing_commas # categories: style
+    - secure_pubspec_urls # categories: pub
+    - slash_for_doc_comments # categories: effective dart,style
+    - sort_constructors_first # categories: style
+    - sort_pub_dependencies # categories: pub
+    - sort_unnamed_constructors_first # categories: style
+    - test_types_in_equals # categories: error-prone
+    - throw_in_finally # categories: error-prone
+    - tighten_type_of_initializing_formals # categories: style
+    - type_annotate_public_apis # categories: effective dart,public interface
+    - type_init_formals # categories: effective dart,style
+    - unawaited_futures # categories: style
+    - unnecessary_await_in_return # categories: style
+    - unnecessary_brace_in_string_interps # categories: brevity,style
+    - unnecessary_const # categories: brevity,style
+    - unnecessary_constructor_name # categories: brevity,style
+    - unnecessary_final # incompatibles: prefer_final_locals,prefer_final_parameters # categories: effective dart,style
+    - unnecessary_getters_setters # categories: effective dart,style
+    - unnecessary_lambdas # categories: style
+    - unnecessary_late # categories: style
+    - unnecessary_new # categories: brevity,language feature usage,style
+    - unnecessary_null_aware_assignments # categories: brevity,effective dart,style
+    - unnecessary_null_checks # categories: brevity,style
+    - unnecessary_null_in_if_null_operators # categories: style
+    - unnecessary_nullable_for_final_variable_declarations # categories: style
+    - unnecessary_overrides # categories: style
+    - unnecessary_parenthesis # categories: brevity,style
+    - unnecessary_raw_strings # categories: brevity,style
+    - unnecessary_statements # categories: brevity,unintentional
+    - unnecessary_string_escapes # categories: brevity,style
+    - unnecessary_string_interpolations # categories: brevity,style
+    - unnecessary_this # categories: brevity,effective dart,style
+    - unrelated_type_equality_checks # categories: unintentional
+    - unsafe_html # categories: errors
+    - use_enums # categories: style
+    - use_function_type_syntax_for_parameters # categories: style
+    - use_if_null_to_convert_nulls_to_bools # categories: effective dart,style
+    - use_is_even_rather_than_modulo # categories: style
+    - use_late_for_private_fields_and_variables # categories: style
+    - use_named_constants # categories: style
+    - use_raw_strings # categories: style
+    - use_rethrow_when_possible # categories: brevity,effective dart
+    - use_setters_to_change_properties # categories: style
+    - use_string_buffers # categories: non-performant
+    - use_super_parameters # categories: brevity
+    - use_test_throws_matchers # categories: style
+    - use_to_and_as_if_applicable # categories: effective dart,style
+    - valid_regexps # categories: unintentional
+    - void_checks # categories: style

--- a/packages/yumemi_lints/lib/dart/2.18/all.yaml
+++ b/packages/yumemi_lints/lib/dart/2.18/all.yaml
@@ -2,195 +2,190 @@
 
 linter:
   rules:
-    # Errors
-    - always_use_package_imports # incompatibles: prefer_relative_imports
-    - avoid_dynamic_calls
-    - avoid_empty_else
-    - avoid_print
-    - avoid_relative_lib_imports
-    - avoid_slow_async_io
-    - avoid_type_to_string
-    - avoid_types_as_parameter_names
-    - cancel_subscriptions
-    - close_sinks
-    - comment_references
-    - control_flow_in_finally
-    - discarded_futures
-    - empty_statements
-    - hash_and_equals
-    - literal_only_boolean_expressions
-    - no_adjacent_strings_in_list
-    - no_duplicate_case_values
-    - prefer_relative_imports # incompatibles: always_use_package_imports
-    - prefer_void_to_null
-    - test_types_in_equals
-    - throw_in_finally
-    - unnecessary_statements
-    - unrelated_type_equality_checks
-    - unsafe_html
-    - valid_regexps
-
-    # Style
-    - always_declare_return_types
-    - always_put_control_body_on_new_line
-    - always_put_required_named_parameters_first
-    - always_specify_types # incompatibles: avoid_types_on_closure_parameters,omit_local_variable_types
-    - annotate_overrides
-    - avoid_annotating_with_dynamic
-    - avoid_bool_literals_in_conditional_expressions
-    - avoid_catches_without_on_clauses
-    - avoid_catching_errors
-    - avoid_classes_with_only_static_members
-    - avoid_double_and_int_checks
-    - avoid_equals_and_hash_code_on_mutable_classes
-    - avoid_escaping_inner_quotes
-    - avoid_field_initializers_in_const_classes
-    - avoid_final_parameters # incompatibles: prefer_final_parameters
-    - avoid_function_literals_in_foreach_calls
-    - avoid_implementing_value_types
-    - avoid_init_to_null
-    - avoid_js_rounded_ints
-    - avoid_multiple_declarations_per_line
-    - avoid_null_checks_in_equality_operators
-    - avoid_positional_boolean_parameters
-    - avoid_private_typedef_functions
-    - avoid_redundant_argument_values
-    - avoid_renaming_method_parameters
-    - avoid_return_types_on_setters
-    - avoid_returning_null_for_void
-    - avoid_returning_this
-    - avoid_setters_without_getters
-    - avoid_shadowing_type_parameters
-    - avoid_single_cascade_in_expression_statements
-    - avoid_types_on_closure_parameters # incompatibles: always_specify_types
-    - avoid_unused_constructor_parameters
-    - avoid_void_async
-    - await_only_futures
-    - camel_case_extensions
-    - camel_case_types
-    - cascade_invocations
-    - cast_nullable_to_non_nullable
-    - conditional_uri_does_not_exist
-    - constant_identifier_names
-    - curly_braces_in_flow_control_structures
-    - deprecated_consistency
-    - directives_ordering
-    - do_not_use_environment
-    - empty_catches
-    - empty_constructor_bodies
-    - eol_at_end_of_file
-    - exhaustive_cases
-    - file_names
-    - flutter_style_todos
-    - implementation_imports
-    - join_return_with_assignment
-    - leading_newlines_in_multiline_strings
-    - library_names
-    - library_prefixes
-    - library_private_types_in_public_api
-    - lines_longer_than_80_chars
-    - missing_whitespace_between_adjacent_strings
-    - no_default_cases
-    - no_leading_underscores_for_library_prefixes
-    - no_leading_underscores_for_local_identifiers
-    - no_runtimeType_toString
-    - non_constant_identifier_names
-    - noop_primitive_operations
-    - null_check_on_nullable_type_parameter
-    - null_closures
-    - omit_local_variable_types # incompatibles: always_specify_types
-    - one_member_abstracts
-    - only_throw_errors
-    - overridden_fields
-    - package_api_docs
-    - package_prefixed_library_names
-    - parameter_assignments
-    - prefer_adjacent_string_concatenation
-    - prefer_asserts_in_initializer_lists
-    - prefer_asserts_with_message
-    - prefer_collection_literals
-    - prefer_conditional_assignment
-    - prefer_const_constructors
-    - prefer_const_constructors_in_immutables
-    - prefer_const_declarations
-    - prefer_const_literals_to_create_immutables
-    - prefer_constructors_over_static_methods
-    - prefer_contains
-    - prefer_double_quotes # incompatibles: prefer_single_quotes
-    - prefer_expression_function_bodies
-    - prefer_final_fields
-    - prefer_final_in_for_each
-    - prefer_final_locals # incompatibles: unnecessary_final
-    - prefer_final_parameters # incompatibles: unnecessary_final,avoid_final_parameters
-    - prefer_for_elements_to_map_fromIterable
-    - prefer_foreach
-    - prefer_function_declarations_over_variables
-    - prefer_generic_function_type_aliases
-    - prefer_if_elements_to_conditional_expressions
-    - prefer_if_null_operators
-    - prefer_initializing_formals
-    - prefer_inlined_adds
-    - prefer_int_literals
-    - prefer_interpolation_to_compose_strings
-    - prefer_is_empty
-    - prefer_is_not_empty
-    - prefer_is_not_operator
-    - prefer_iterable_whereType
-    - prefer_mixin
-    - prefer_null_aware_method_calls
-    - prefer_null_aware_operators
-    - prefer_single_quotes # incompatibles: prefer_double_quotes
-    - prefer_spread_collections
-    - prefer_typing_uninitialized_variables
-    - provide_deprecation_message
-    - public_member_api_docs
-    - recursive_getters
-    - require_trailing_commas
-    - slash_for_doc_comments
-    - sort_constructors_first
-    - sort_unnamed_constructors_first
-    - tighten_type_of_initializing_formals
-    - type_annotate_public_apis
-    - type_init_formals
-    - unawaited_futures
-    - unnecessary_await_in_return
-    - unnecessary_brace_in_string_interps
-    - unnecessary_const
-    - unnecessary_constructor_name
-    - unnecessary_final # incompatibles: prefer_final_locals,prefer_final_parameters
-    - unnecessary_getters_setters
-    - unnecessary_lambdas
-    - unnecessary_late
-    - unnecessary_new
-    - unnecessary_null_aware_assignments
-    - unnecessary_null_aware_operator_on_extension_on_nullable
-    - unnecessary_null_checks
-    - unnecessary_null_in_if_null_operators
-    - unnecessary_nullable_for_final_variable_declarations
-    - unnecessary_overrides
-    - unnecessary_parenthesis
-    - unnecessary_raw_strings
-    - unnecessary_string_escapes
-    - unnecessary_string_interpolations
-    - unnecessary_this
-    - unnecessary_to_list_in_spreads
-    - use_enums
-    - use_function_type_syntax_for_parameters
-    - use_if_null_to_convert_nulls_to_bools
-    - use_is_even_rather_than_modulo
-    - use_late_for_private_fields_and_variables
-    - use_named_constants
-    - use_raw_strings
-    - use_rethrow_when_possible
-    - use_setters_to_change_properties
-    - use_string_buffers
-    - use_super_parameters
-    - use_test_throws_matchers
-    - use_to_and_as_if_applicable
-    - void_checks
-
-    # Pub
-    - depend_on_referenced_packages
-    - package_names
-    - secure_pubspec_urls
-    - sort_pub_dependencies
+    - always_declare_return_types # categories: style
+    - always_put_control_body_on_new_line # categories: style
+    - always_put_required_named_parameters_first # categories: style
+    - always_specify_types # incompatibles: avoid_types_on_closure_parameters,omit_local_variable_types,omit_obvious_local_variable_types # categories: style
+    - always_use_package_imports # incompatibles: prefer_relative_imports # categories: error-prone
+    - annotate_overrides # categories: style
+    - avoid_annotating_with_dynamic # categories: brevity,style
+    - avoid_bool_literals_in_conditional_expressions # categories: brevity
+    - avoid_catches_without_on_clauses # categories: effective dart,style
+    - avoid_catching_errors # categories: style
+    - avoid_classes_with_only_static_members # categories: effective dart,language feature usage,style
+    - avoid_double_and_int_checks # categories: error-prone,web
+    - avoid_dynamic_calls # categories: binary size,error-prone
+    - avoid_empty_else # categories: brevity,error-prone
+    - avoid_equals_and_hash_code_on_mutable_classes # categories: effective dart,style
+    - avoid_escaping_inner_quotes # categories: style
+    - avoid_field_initializers_in_const_classes # categories: style
+    - avoid_final_parameters # incompatibles: prefer_final_parameters # categories: style
+    - avoid_function_literals_in_foreach_calls # categories: style
+    - avoid_implementing_value_types # categories: style
+    - avoid_init_to_null # categories: brevity,effective dart,style
+    - avoid_js_rounded_ints # categories: error-prone,web
+    - avoid_multiple_declarations_per_line # categories: style
+    - avoid_null_checks_in_equality_operators # categories: style
+    - avoid_positional_boolean_parameters # categories: effective dart,style
+    - avoid_print # categories: unintentional
+    - avoid_private_typedef_functions # categories: style
+    - avoid_redundant_argument_values # categories: brevity,style
+    - avoid_relative_lib_imports # categories: error-prone
+    - avoid_renaming_method_parameters # categories: documentation comment maintenance
+    - avoid_return_types_on_setters # categories: brevity,style
+    - avoid_returning_null_for_void # categories: style
+    - avoid_returning_this # categories: effective dart,style
+    - avoid_setters_without_getters # categories: style
+    - avoid_shadowing_type_parameters # categories: error-prone
+    - avoid_single_cascade_in_expression_statements # categories: brevity,style
+    - avoid_slow_async_io # categories: non-performant
+    - avoid_type_to_string # categories: unintentional
+    - avoid_types_as_parameter_names # categories: unintentional
+    - avoid_types_on_closure_parameters # incompatibles: always_specify_types # categories: style
+    - avoid_unused_constructor_parameters # categories: unintentional
+    - avoid_void_async # categories: style
+    - await_only_futures # categories: style
+    - camel_case_extensions # categories: effective dart,style
+    - camel_case_types # categories: effective dart,style
+    - cancel_subscriptions # categories: error-prone,memory leaks
+    - cascade_invocations # categories: brevity,language feature usage,style
+    - cast_nullable_to_non_nullable # categories: error-prone
+    - close_sinks # categories: error-prone,memory leaks
+    - comment_references # categories: documentation comment maintenance
+    - conditional_uri_does_not_exist # categories: error-prone
+    - constant_identifier_names # categories: style
+    - control_flow_in_finally # categories: error-prone
+    - curly_braces_in_flow_control_structures # categories: error-prone
+    - depend_on_referenced_packages # categories: pub
+    - deprecated_consistency # categories: style
+    - directives_ordering # categories: style
+    - discarded_futures # categories: error-prone
+    - do_not_use_environment # categories: error-prone
+    - empty_catches # categories: style
+    - empty_constructor_bodies # categories: brevity,effective dart,style
+    - empty_statements # categories: error-prone
+    - eol_at_end_of_file # categories: style
+    - exhaustive_cases # categories: error-prone
+    - file_names # categories: style
+    - flutter_style_todos # categories: style
+    - hash_and_equals # categories: error-prone
+    - implementation_imports # categories: style
+    - join_return_with_assignment # categories: brevity,style
+    - leading_newlines_in_multiline_strings # categories: style
+    - library_names # categories: style
+    - library_prefixes # categories: style
+    - library_private_types_in_public_api # categories: public interface
+    - lines_longer_than_80_chars # categories: style
+    - literal_only_boolean_expressions # categories: unused code
+    - missing_whitespace_between_adjacent_strings # categories: error-prone
+    - no_adjacent_strings_in_list # categories: style
+    - no_default_cases # categories: style
+    - no_duplicate_case_values # categories: error-prone
+    - no_leading_underscores_for_library_prefixes # categories: style
+    - no_leading_underscores_for_local_identifiers # categories: style
+    - no_runtimeType_toString # categories: non-performant
+    - non_constant_identifier_names # categories: style
+    - noop_primitive_operations # categories: style
+    - null_check_on_nullable_type_parameter # categories: style
+    - null_closures # categories: error-prone
+    - omit_local_variable_types # incompatibles: always_specify_types # categories: style
+    - one_member_abstracts # categories: effective dart,language feature usage,style
+    - only_throw_errors # categories: style
+    - overridden_fields # categories: style
+    - package_api_docs # categories: effective dart,public interface
+    - package_names # categories: style
+    - package_prefixed_library_names # categories: style
+    - parameter_assignments # categories: style
+    - prefer_adjacent_string_concatenation # categories: style
+    - prefer_asserts_in_initializer_lists # categories: style
+    - prefer_asserts_with_message # categories: style
+    - prefer_collection_literals # categories: brevity,style
+    - prefer_conditional_assignment # categories: brevity,style
+    - prefer_const_constructors # categories: style
+    - prefer_const_constructors_in_immutables # categories: style
+    - prefer_const_declarations # categories: style
+    - prefer_const_literals_to_create_immutables # categories: style
+    - prefer_constructors_over_static_methods # categories: style
+    - prefer_contains # categories: style
+    - prefer_double_quotes # incompatibles: prefer_single_quotes # categories: style
+    - prefer_expression_function_bodies # categories: brevity,style
+    - prefer_final_fields # categories: effective dart,style
+    - prefer_final_in_for_each # categories: style
+    - prefer_final_locals # incompatibles: unnecessary_final # categories: style
+    - prefer_final_parameters # incompatibles: unnecessary_final,avoid_final_parameters # categories: style
+    - prefer_for_elements_to_map_fromIterable # categories: brevity,style
+    - prefer_foreach # categories: style
+    - prefer_function_declarations_over_variables # categories: effective dart,style
+    - prefer_generic_function_type_aliases # categories: style
+    - prefer_if_elements_to_conditional_expressions # categories: brevity,style
+    - prefer_if_null_operators # categories: brevity,style
+    - prefer_initializing_formals # categories: brevity,style
+    - prefer_inlined_adds # categories: brevity,style
+    - prefer_int_literals # categories: style
+    - prefer_interpolation_to_compose_strings # categories: style
+    - prefer_is_empty # categories: style
+    - prefer_is_not_empty # categories: style
+    - prefer_is_not_operator # categories: brevity,style
+    - prefer_iterable_whereType # categories: style
+    - prefer_mixin # categories: language feature usage,style
+    - prefer_null_aware_method_calls # categories: brevity,style
+    - prefer_null_aware_operators # categories: brevity,style
+    - prefer_relative_imports # incompatibles: always_use_package_imports # categories: error-prone
+    - prefer_single_quotes # incompatibles: prefer_double_quotes # categories: style
+    - prefer_spread_collections # categories: brevity,style
+    - prefer_typing_uninitialized_variables # categories: error-prone,unintentional
+    - prefer_void_to_null # categories: error-prone
+    - provide_deprecation_message # categories: public interface
+    - public_member_api_docs # categories: public interface,style
+    - recursive_getters # categories: error-prone,unintentional
+    - require_trailing_commas # categories: style
+    - secure_pubspec_urls # categories: pub
+    - slash_for_doc_comments # categories: effective dart,style
+    - sort_constructors_first # categories: style
+    - sort_pub_dependencies # categories: pub
+    - sort_unnamed_constructors_first # categories: style
+    - test_types_in_equals # categories: error-prone
+    - throw_in_finally # categories: error-prone
+    - tighten_type_of_initializing_formals # categories: style
+    - type_annotate_public_apis # categories: effective dart,public interface
+    - type_init_formals # categories: effective dart,style
+    - unawaited_futures # categories: style
+    - unnecessary_await_in_return # categories: style
+    - unnecessary_brace_in_string_interps # categories: brevity,style
+    - unnecessary_const # categories: brevity,style
+    - unnecessary_constructor_name # categories: brevity,style
+    - unnecessary_final # incompatibles: prefer_final_locals,prefer_final_parameters # categories: effective dart,style
+    - unnecessary_getters_setters # categories: effective dart,style
+    - unnecessary_lambdas # categories: style
+    - unnecessary_late # categories: style
+    - unnecessary_new # categories: brevity,language feature usage,style
+    - unnecessary_null_aware_assignments # categories: brevity,effective dart,style
+    - unnecessary_null_aware_operator_on_extension_on_nullable # categories: style
+    - unnecessary_null_checks # categories: brevity,style
+    - unnecessary_null_in_if_null_operators # categories: style
+    - unnecessary_nullable_for_final_variable_declarations # categories: style
+    - unnecessary_overrides # categories: style
+    - unnecessary_parenthesis # categories: brevity,style
+    - unnecessary_raw_strings # categories: brevity,style
+    - unnecessary_statements # categories: brevity,unintentional
+    - unnecessary_string_escapes # categories: brevity,style
+    - unnecessary_string_interpolations # categories: brevity,style
+    - unnecessary_this # categories: brevity,effective dart,style
+    - unnecessary_to_list_in_spreads # categories: brevity
+    - unrelated_type_equality_checks # categories: unintentional
+    - unsafe_html # categories: errors
+    - use_enums # categories: style
+    - use_function_type_syntax_for_parameters # categories: style
+    - use_if_null_to_convert_nulls_to_bools # categories: effective dart,style
+    - use_is_even_rather_than_modulo # categories: style
+    - use_late_for_private_fields_and_variables # categories: style
+    - use_named_constants # categories: style
+    - use_raw_strings # categories: style
+    - use_rethrow_when_possible # categories: brevity,effective dart
+    - use_setters_to_change_properties # categories: style
+    - use_string_buffers # categories: non-performant
+    - use_super_parameters # categories: brevity
+    - use_test_throws_matchers # categories: style
+    - use_to_and_as_if_applicable # categories: effective dart,style
+    - valid_regexps # categories: unintentional
+    - void_checks # categories: style

--- a/packages/yumemi_lints/lib/dart/2.19/all.yaml
+++ b/packages/yumemi_lints/lib/dart/2.19/all.yaml
@@ -2,203 +2,198 @@
 
 linter:
   rules:
-    # Errors
-    - always_use_package_imports # incompatibles: prefer_relative_imports
-    - avoid_dynamic_calls
-    - avoid_empty_else
-    - avoid_print
-    - avoid_relative_lib_imports
-    - avoid_slow_async_io
-    - avoid_type_to_string
-    - avoid_types_as_parameter_names
-    - cancel_subscriptions
-    - close_sinks
-    - collection_methods_unrelated_type
-    - comment_references
-    - control_flow_in_finally
-    - discarded_futures
-    - empty_statements
-    - hash_and_equals
-    - literal_only_boolean_expressions
-    - no_adjacent_strings_in_list
-    - no_duplicate_case_values
-    - prefer_relative_imports # incompatibles: always_use_package_imports
-    - prefer_void_to_null
-    - test_types_in_equals
-    - throw_in_finally
-    - unnecessary_statements
-    - unrelated_type_equality_checks
-    - unsafe_html
-    - valid_regexps
-
-    # Style
-    - always_declare_return_types
-    - always_put_control_body_on_new_line
-    - always_put_required_named_parameters_first
-    - always_specify_types # incompatibles: avoid_types_on_closure_parameters,omit_local_variable_types
-    - annotate_overrides
-    - avoid_annotating_with_dynamic
-    - avoid_bool_literals_in_conditional_expressions
-    - avoid_catches_without_on_clauses
-    - avoid_catching_errors
-    - avoid_classes_with_only_static_members
-    - avoid_double_and_int_checks
-    - avoid_equals_and_hash_code_on_mutable_classes
-    - avoid_escaping_inner_quotes
-    - avoid_field_initializers_in_const_classes
-    - avoid_final_parameters # incompatibles: prefer_final_parameters
-    - avoid_function_literals_in_foreach_calls
-    - avoid_implementing_value_types
-    - avoid_init_to_null
-    - avoid_js_rounded_ints
-    - avoid_multiple_declarations_per_line
-    - avoid_null_checks_in_equality_operators
-    - avoid_positional_boolean_parameters
-    - avoid_private_typedef_functions
-    - avoid_redundant_argument_values
-    - avoid_renaming_method_parameters
-    - avoid_return_types_on_setters
-    - avoid_returning_null_for_void
-    - avoid_returning_this
-    - avoid_setters_without_getters
-    - avoid_shadowing_type_parameters
-    - avoid_single_cascade_in_expression_statements
-    - avoid_types_on_closure_parameters # incompatibles: always_specify_types
-    - avoid_unused_constructor_parameters
-    - avoid_void_async
-    - await_only_futures
-    - camel_case_extensions
-    - camel_case_types
-    - cascade_invocations
-    - cast_nullable_to_non_nullable
-    - combinators_ordering
-    - conditional_uri_does_not_exist
-    - constant_identifier_names
-    - curly_braces_in_flow_control_structures
-    - dangling_library_doc_comments
-    - deprecated_consistency
-    - directives_ordering
-    - do_not_use_environment
-    - empty_catches
-    - empty_constructor_bodies
-    - eol_at_end_of_file
-    - exhaustive_cases
-    - file_names
-    - flutter_style_todos
-    - implementation_imports
-    - implicit_call_tearoffs
-    - join_return_with_assignment
-    - leading_newlines_in_multiline_strings
-    - library_annotations
-    - library_names
-    - library_prefixes
-    - library_private_types_in_public_api
-    - lines_longer_than_80_chars
-    - missing_whitespace_between_adjacent_strings
-    - no_default_cases
-    - no_leading_underscores_for_library_prefixes
-    - no_leading_underscores_for_local_identifiers
-    - no_runtimeType_toString
-    - non_constant_identifier_names
-    - noop_primitive_operations
-    - null_check_on_nullable_type_parameter
-    - null_closures
-    - omit_local_variable_types # incompatibles: always_specify_types
-    - one_member_abstracts
-    - only_throw_errors
-    - overridden_fields
-    - package_api_docs
-    - package_prefixed_library_names
-    - parameter_assignments
-    - prefer_adjacent_string_concatenation
-    - prefer_asserts_in_initializer_lists
-    - prefer_asserts_with_message
-    - prefer_collection_literals
-    - prefer_conditional_assignment
-    - prefer_const_constructors
-    - prefer_const_constructors_in_immutables
-    - prefer_const_declarations
-    - prefer_const_literals_to_create_immutables
-    - prefer_constructors_over_static_methods
-    - prefer_contains
-    - prefer_double_quotes # incompatibles: prefer_single_quotes
-    - prefer_expression_function_bodies
-    - prefer_final_fields
-    - prefer_final_in_for_each
-    - prefer_final_locals # incompatibles: unnecessary_final
-    - prefer_final_parameters # incompatibles: unnecessary_final,avoid_final_parameters
-    - prefer_for_elements_to_map_fromIterable
-    - prefer_foreach
-    - prefer_function_declarations_over_variables
-    - prefer_generic_function_type_aliases
-    - prefer_if_elements_to_conditional_expressions
-    - prefer_if_null_operators
-    - prefer_initializing_formals
-    - prefer_inlined_adds
-    - prefer_int_literals
-    - prefer_interpolation_to_compose_strings
-    - prefer_is_empty
-    - prefer_is_not_empty
-    - prefer_is_not_operator
-    - prefer_iterable_whereType
-    - prefer_mixin
-    - prefer_null_aware_method_calls
-    - prefer_null_aware_operators
-    - prefer_single_quotes # incompatibles: prefer_double_quotes
-    - prefer_spread_collections
-    - prefer_typing_uninitialized_variables
-    - provide_deprecation_message
-    - public_member_api_docs
-    - recursive_getters
-    - require_trailing_commas
-    - slash_for_doc_comments
-    - sort_constructors_first
-    - sort_unnamed_constructors_first
-    - tighten_type_of_initializing_formals
-    - type_annotate_public_apis
-    - type_init_formals
-    - unawaited_futures
-    - unnecessary_await_in_return
-    - unnecessary_brace_in_string_interps
-    - unnecessary_const
-    - unnecessary_constructor_name
-    - unnecessary_final # incompatibles: prefer_final_locals,prefer_final_parameters
-    - unnecessary_getters_setters
-    - unnecessary_lambdas
-    - unnecessary_late
-    - unnecessary_library_directive
-    - unnecessary_new
-    - unnecessary_null_aware_assignments
-    - unnecessary_null_aware_operator_on_extension_on_nullable
-    - unnecessary_null_checks
-    - unnecessary_null_in_if_null_operators
-    - unnecessary_nullable_for_final_variable_declarations
-    - unnecessary_overrides
-    - unnecessary_parenthesis
-    - unnecessary_raw_strings
-    - unnecessary_string_escapes
-    - unnecessary_string_interpolations
-    - unnecessary_this
-    - unnecessary_to_list_in_spreads
-    - unreachable_from_main
-    - use_enums
-    - use_function_type_syntax_for_parameters
-    - use_if_null_to_convert_nulls_to_bools
-    - use_is_even_rather_than_modulo
-    - use_late_for_private_fields_and_variables
-    - use_named_constants
-    - use_raw_strings
-    - use_rethrow_when_possible
-    - use_setters_to_change_properties
-    - use_string_buffers
-    - use_string_in_part_of_directives
-    - use_super_parameters
-    - use_test_throws_matchers
-    - use_to_and_as_if_applicable
-    - void_checks
-
-    # Pub
-    - depend_on_referenced_packages
-    - package_names
-    - secure_pubspec_urls
-    - sort_pub_dependencies
+    - always_declare_return_types # categories: style
+    - always_put_control_body_on_new_line # categories: style
+    - always_put_required_named_parameters_first # categories: style
+    - always_specify_types # incompatibles: avoid_types_on_closure_parameters,omit_local_variable_types,omit_obvious_local_variable_types # categories: style
+    - always_use_package_imports # incompatibles: prefer_relative_imports # categories: error-prone
+    - annotate_overrides # categories: style
+    - avoid_annotating_with_dynamic # categories: brevity,style
+    - avoid_bool_literals_in_conditional_expressions # categories: brevity
+    - avoid_catches_without_on_clauses # categories: effective dart,style
+    - avoid_catching_errors # categories: style
+    - avoid_classes_with_only_static_members # categories: effective dart,language feature usage,style
+    - avoid_double_and_int_checks # categories: error-prone,web
+    - avoid_dynamic_calls # categories: binary size,error-prone
+    - avoid_empty_else # categories: brevity,error-prone
+    - avoid_equals_and_hash_code_on_mutable_classes # categories: effective dart,style
+    - avoid_escaping_inner_quotes # categories: style
+    - avoid_field_initializers_in_const_classes # categories: style
+    - avoid_final_parameters # incompatibles: prefer_final_parameters # categories: style
+    - avoid_function_literals_in_foreach_calls # categories: style
+    - avoid_implementing_value_types # categories: style
+    - avoid_init_to_null # categories: brevity,effective dart,style
+    - avoid_js_rounded_ints # categories: error-prone,web
+    - avoid_multiple_declarations_per_line # categories: style
+    - avoid_null_checks_in_equality_operators # categories: style
+    - avoid_positional_boolean_parameters # categories: effective dart,style
+    - avoid_print # categories: unintentional
+    - avoid_private_typedef_functions # categories: style
+    - avoid_redundant_argument_values # categories: brevity,style
+    - avoid_relative_lib_imports # categories: error-prone
+    - avoid_renaming_method_parameters # categories: documentation comment maintenance
+    - avoid_return_types_on_setters # categories: brevity,style
+    - avoid_returning_null_for_void # categories: style
+    - avoid_returning_this # categories: effective dart,style
+    - avoid_setters_without_getters # categories: style
+    - avoid_shadowing_type_parameters # categories: error-prone
+    - avoid_single_cascade_in_expression_statements # categories: brevity,style
+    - avoid_slow_async_io # categories: non-performant
+    - avoid_type_to_string # categories: unintentional
+    - avoid_types_as_parameter_names # categories: unintentional
+    - avoid_types_on_closure_parameters # incompatibles: always_specify_types # categories: style
+    - avoid_unused_constructor_parameters # categories: unintentional
+    - avoid_void_async # categories: style
+    - await_only_futures # categories: style
+    - camel_case_extensions # categories: effective dart,style
+    - camel_case_types # categories: effective dart,style
+    - cancel_subscriptions # categories: error-prone,memory leaks
+    - cascade_invocations # categories: brevity,language feature usage,style
+    - cast_nullable_to_non_nullable # categories: error-prone
+    - close_sinks # categories: error-prone,memory leaks
+    - collection_methods_unrelated_type # categories: unintentional
+    - combinators_ordering # categories: style
+    - comment_references # categories: documentation comment maintenance
+    - conditional_uri_does_not_exist # categories: error-prone
+    - constant_identifier_names # categories: style
+    - control_flow_in_finally # categories: error-prone
+    - curly_braces_in_flow_control_structures # categories: error-prone
+    - dangling_library_doc_comments # categories: documentation comment maintenance
+    - depend_on_referenced_packages # categories: pub
+    - deprecated_consistency # categories: style
+    - directives_ordering # categories: style
+    - discarded_futures # categories: error-prone
+    - do_not_use_environment # categories: error-prone
+    - empty_catches # categories: style
+    - empty_constructor_bodies # categories: brevity,effective dart,style
+    - empty_statements # categories: error-prone
+    - eol_at_end_of_file # categories: style
+    - exhaustive_cases # categories: error-prone
+    - file_names # categories: style
+    - flutter_style_todos # categories: style
+    - hash_and_equals # categories: error-prone
+    - implementation_imports # categories: style
+    - implicit_call_tearoffs # categories: style
+    - join_return_with_assignment # categories: brevity,style
+    - leading_newlines_in_multiline_strings # categories: style
+    - library_annotations # categories: style
+    - library_names # categories: style
+    - library_prefixes # categories: style
+    - library_private_types_in_public_api # categories: public interface
+    - lines_longer_than_80_chars # categories: style
+    - literal_only_boolean_expressions # categories: unused code
+    - missing_whitespace_between_adjacent_strings # categories: error-prone
+    - no_adjacent_strings_in_list # categories: style
+    - no_default_cases # categories: style
+    - no_duplicate_case_values # categories: error-prone
+    - no_leading_underscores_for_library_prefixes # categories: style
+    - no_leading_underscores_for_local_identifiers # categories: style
+    - no_runtimeType_toString # categories: non-performant
+    - non_constant_identifier_names # categories: style
+    - noop_primitive_operations # categories: style
+    - null_check_on_nullable_type_parameter # categories: style
+    - null_closures # categories: error-prone
+    - omit_local_variable_types # incompatibles: always_specify_types # categories: style
+    - one_member_abstracts # categories: effective dart,language feature usage,style
+    - only_throw_errors # categories: style
+    - overridden_fields # categories: style
+    - package_api_docs # categories: effective dart,public interface
+    - package_names # categories: style
+    - package_prefixed_library_names # categories: style
+    - parameter_assignments # categories: style
+    - prefer_adjacent_string_concatenation # categories: style
+    - prefer_asserts_in_initializer_lists # categories: style
+    - prefer_asserts_with_message # categories: style
+    - prefer_collection_literals # categories: brevity,style
+    - prefer_conditional_assignment # categories: brevity,style
+    - prefer_const_constructors # categories: style
+    - prefer_const_constructors_in_immutables # categories: style
+    - prefer_const_declarations # categories: style
+    - prefer_const_literals_to_create_immutables # categories: style
+    - prefer_constructors_over_static_methods # categories: style
+    - prefer_contains # categories: style
+    - prefer_double_quotes # incompatibles: prefer_single_quotes # categories: style
+    - prefer_expression_function_bodies # categories: brevity,style
+    - prefer_final_fields # categories: effective dart,style
+    - prefer_final_in_for_each # categories: style
+    - prefer_final_locals # incompatibles: unnecessary_final # categories: style
+    - prefer_final_parameters # incompatibles: unnecessary_final,avoid_final_parameters # categories: style
+    - prefer_for_elements_to_map_fromIterable # categories: brevity,style
+    - prefer_foreach # categories: style
+    - prefer_function_declarations_over_variables # categories: effective dart,style
+    - prefer_generic_function_type_aliases # categories: style
+    - prefer_if_elements_to_conditional_expressions # categories: brevity,style
+    - prefer_if_null_operators # categories: brevity,style
+    - prefer_initializing_formals # categories: brevity,style
+    - prefer_inlined_adds # categories: brevity,style
+    - prefer_int_literals # categories: style
+    - prefer_interpolation_to_compose_strings # categories: style
+    - prefer_is_empty # categories: style
+    - prefer_is_not_empty # categories: style
+    - prefer_is_not_operator # categories: brevity,style
+    - prefer_iterable_whereType # categories: style
+    - prefer_mixin # categories: language feature usage,style
+    - prefer_null_aware_method_calls # categories: brevity,style
+    - prefer_null_aware_operators # categories: brevity,style
+    - prefer_relative_imports # incompatibles: always_use_package_imports # categories: error-prone
+    - prefer_single_quotes # incompatibles: prefer_double_quotes # categories: style
+    - prefer_spread_collections # categories: brevity,style
+    - prefer_typing_uninitialized_variables # categories: error-prone,unintentional
+    - prefer_void_to_null # categories: error-prone
+    - provide_deprecation_message # categories: public interface
+    - public_member_api_docs # categories: public interface,style
+    - recursive_getters # categories: error-prone,unintentional
+    - require_trailing_commas # categories: style
+    - secure_pubspec_urls # categories: pub
+    - slash_for_doc_comments # categories: effective dart,style
+    - sort_constructors_first # categories: style
+    - sort_pub_dependencies # categories: pub
+    - sort_unnamed_constructors_first # categories: style
+    - test_types_in_equals # categories: error-prone
+    - throw_in_finally # categories: error-prone
+    - tighten_type_of_initializing_formals # categories: style
+    - type_annotate_public_apis # categories: effective dart,public interface
+    - type_init_formals # categories: effective dart,style
+    - unawaited_futures # categories: style
+    - unnecessary_await_in_return # categories: style
+    - unnecessary_brace_in_string_interps # categories: brevity,style
+    - unnecessary_const # categories: brevity,style
+    - unnecessary_constructor_name # categories: brevity,style
+    - unnecessary_final # incompatibles: prefer_final_locals,prefer_final_parameters # categories: effective dart,style
+    - unnecessary_getters_setters # categories: effective dart,style
+    - unnecessary_lambdas # categories: style
+    - unnecessary_late # categories: style
+    - unnecessary_library_directive # categories: brevity
+    - unnecessary_new # categories: brevity,language feature usage,style
+    - unnecessary_null_aware_assignments # categories: brevity,effective dart,style
+    - unnecessary_null_aware_operator_on_extension_on_nullable # categories: style
+    - unnecessary_null_checks # categories: brevity,style
+    - unnecessary_null_in_if_null_operators # categories: style
+    - unnecessary_nullable_for_final_variable_declarations # categories: style
+    - unnecessary_overrides # categories: style
+    - unnecessary_parenthesis # categories: brevity,style
+    - unnecessary_raw_strings # categories: brevity,style
+    - unnecessary_statements # categories: brevity,unintentional
+    - unnecessary_string_escapes # categories: brevity,style
+    - unnecessary_string_interpolations # categories: brevity,style
+    - unnecessary_this # categories: brevity,effective dart,style
+    - unnecessary_to_list_in_spreads # categories: brevity
+    - unreachable_from_main # categories: unused code
+    - unrelated_type_equality_checks # categories: unintentional
+    - unsafe_html # categories: errors
+    - use_enums # categories: style
+    - use_function_type_syntax_for_parameters # categories: style
+    - use_if_null_to_convert_nulls_to_bools # categories: effective dart,style
+    - use_is_even_rather_than_modulo # categories: style
+    - use_late_for_private_fields_and_variables # categories: style
+    - use_named_constants # categories: style
+    - use_raw_strings # categories: style
+    - use_rethrow_when_possible # categories: brevity,effective dart
+    - use_setters_to_change_properties # categories: style
+    - use_string_buffers # categories: non-performant
+    - use_string_in_part_of_directives # categories: effective dart,style
+    - use_super_parameters # categories: brevity
+    - use_test_throws_matchers # categories: style
+    - use_to_and_as_if_applicable # categories: effective dart,style
+    - valid_regexps # categories: unintentional
+    - void_checks # categories: style

--- a/packages/yumemi_lints/lib/dart/3.0/all.yaml
+++ b/packages/yumemi_lints/lib/dart/3.0/all.yaml
@@ -2,210 +2,205 @@
 
 linter:
   rules:
-    # Errors
-    - always_use_package_imports # incompatibles: prefer_relative_imports
-    - avoid_dynamic_calls
-    - avoid_empty_else
-    - avoid_print
-    - avoid_relative_lib_imports
-    - avoid_slow_async_io
-    - avoid_type_to_string
-    - avoid_types_as_parameter_names
-    - cancel_subscriptions
-    - close_sinks
-    - collection_methods_unrelated_type
-    - comment_references
-    - control_flow_in_finally
-    - deprecated_member_use_from_same_package
-    - discarded_futures
-    - empty_statements
-    - hash_and_equals
-    - implicit_reopen
-    - invalid_case_patterns
-    - literal_only_boolean_expressions
-    - no_adjacent_strings_in_list
-    - no_duplicate_case_values
-    - prefer_relative_imports # incompatibles: always_use_package_imports
-    - prefer_void_to_null
-    - test_types_in_equals
-    - throw_in_finally
-    - unnecessary_statements
-    - unrelated_type_equality_checks
-    - unsafe_html
-    - valid_regexps
-
-    # Style
-    - always_declare_return_types
-    - always_put_control_body_on_new_line
-    - always_put_required_named_parameters_first
-    - always_specify_types # incompatibles: avoid_types_on_closure_parameters,omit_local_variable_types
-    - annotate_overrides
-    - avoid_annotating_with_dynamic
-    - avoid_bool_literals_in_conditional_expressions
-    - avoid_catches_without_on_clauses
-    - avoid_catching_errors
-    - avoid_classes_with_only_static_members
-    - avoid_double_and_int_checks
-    - avoid_equals_and_hash_code_on_mutable_classes
-    - avoid_escaping_inner_quotes
-    - avoid_field_initializers_in_const_classes
-    - avoid_final_parameters # incompatibles: prefer_final_parameters
-    - avoid_function_literals_in_foreach_calls
-    - avoid_implementing_value_types
-    - avoid_init_to_null
-    - avoid_js_rounded_ints
-    - avoid_multiple_declarations_per_line
-    - avoid_null_checks_in_equality_operators
-    - avoid_positional_boolean_parameters
-    - avoid_private_typedef_functions
-    - avoid_redundant_argument_values
-    - avoid_renaming_method_parameters
-    - avoid_return_types_on_setters
-    - avoid_returning_null_for_void
-    - avoid_returning_this
-    - avoid_setters_without_getters
-    - avoid_shadowing_type_parameters
-    - avoid_single_cascade_in_expression_statements
-    - avoid_types_on_closure_parameters # incompatibles: always_specify_types
-    - avoid_unused_constructor_parameters
-    - avoid_void_async
-    - await_only_futures
-    - camel_case_extensions
-    - camel_case_types
-    - cascade_invocations
-    - cast_nullable_to_non_nullable
-    - combinators_ordering
-    - conditional_uri_does_not_exist
-    - constant_identifier_names
-    - curly_braces_in_flow_control_structures
-    - dangling_library_doc_comments
-    - deprecated_consistency
-    - directives_ordering
-    - do_not_use_environment
-    - empty_catches
-    - empty_constructor_bodies
-    - eol_at_end_of_file
-    - exhaustive_cases
-    - file_names
-    - flutter_style_todos
-    - implementation_imports
-    - implicit_call_tearoffs
-    - join_return_with_assignment
-    - leading_newlines_in_multiline_strings
-    - library_annotations
-    - library_names
-    - library_prefixes
-    - library_private_types_in_public_api
-    - lines_longer_than_80_chars
-    - matching_super_parameters
-    - missing_whitespace_between_adjacent_strings
-    - no_default_cases
-    - no_leading_underscores_for_library_prefixes
-    - no_leading_underscores_for_local_identifiers
-    - no_literal_bool_comparisons
-    - no_runtimeType_toString
-    - non_constant_identifier_names
-    - noop_primitive_operations
-    - null_check_on_nullable_type_parameter
-    - null_closures
-    - omit_local_variable_types # incompatibles: always_specify_types
-    - one_member_abstracts
-    - only_throw_errors
-    - overridden_fields
-    - package_api_docs
-    - package_prefixed_library_names
-    - parameter_assignments
-    - prefer_adjacent_string_concatenation
-    - prefer_asserts_in_initializer_lists
-    - prefer_asserts_with_message
-    - prefer_collection_literals
-    - prefer_conditional_assignment
-    - prefer_const_constructors
-    - prefer_const_constructors_in_immutables
-    - prefer_const_declarations
-    - prefer_const_literals_to_create_immutables
-    - prefer_constructors_over_static_methods
-    - prefer_contains
-    - prefer_double_quotes # incompatibles: prefer_single_quotes
-    - prefer_expression_function_bodies
-    - prefer_final_fields
-    - prefer_final_in_for_each
-    - prefer_final_locals # incompatibles: unnecessary_final
-    - prefer_final_parameters # incompatibles: unnecessary_final,avoid_final_parameters
-    - prefer_for_elements_to_map_fromIterable
-    - prefer_foreach
-    - prefer_function_declarations_over_variables
-    - prefer_generic_function_type_aliases
-    - prefer_if_elements_to_conditional_expressions
-    - prefer_if_null_operators
-    - prefer_initializing_formals
-    - prefer_inlined_adds
-    - prefer_int_literals
-    - prefer_interpolation_to_compose_strings
-    - prefer_is_empty
-    - prefer_is_not_empty
-    - prefer_is_not_operator
-    - prefer_iterable_whereType
-    - prefer_mixin
-    - prefer_null_aware_method_calls
-    - prefer_null_aware_operators
-    - prefer_single_quotes # incompatibles: prefer_double_quotes
-    - prefer_spread_collections
-    - prefer_typing_uninitialized_variables
-    - provide_deprecation_message
-    - public_member_api_docs
-    - recursive_getters
-    - require_trailing_commas
-    - slash_for_doc_comments
-    - sort_constructors_first
-    - sort_unnamed_constructors_first
-    - tighten_type_of_initializing_formals
-    - type_annotate_public_apis
-    - type_init_formals
-    - type_literal_in_constant_pattern
-    - unawaited_futures
-    - unnecessary_await_in_return
-    - unnecessary_brace_in_string_interps
-    - unnecessary_breaks
-    - unnecessary_const
-    - unnecessary_constructor_name
-    - unnecessary_final # incompatibles: prefer_final_locals,prefer_final_parameters
-    - unnecessary_getters_setters
-    - unnecessary_lambdas
-    - unnecessary_late
-    - unnecessary_library_directive
-    - unnecessary_new
-    - unnecessary_null_aware_assignments
-    - unnecessary_null_aware_operator_on_extension_on_nullable
-    - unnecessary_null_checks
-    - unnecessary_null_in_if_null_operators
-    - unnecessary_nullable_for_final_variable_declarations
-    - unnecessary_overrides
-    - unnecessary_parenthesis
-    - unnecessary_raw_strings
-    - unnecessary_string_escapes
-    - unnecessary_string_interpolations
-    - unnecessary_this
-    - unnecessary_to_list_in_spreads
-    - unreachable_from_main
-    - use_enums
-    - use_function_type_syntax_for_parameters
-    - use_if_null_to_convert_nulls_to_bools
-    - use_is_even_rather_than_modulo
-    - use_late_for_private_fields_and_variables
-    - use_named_constants
-    - use_raw_strings
-    - use_rethrow_when_possible
-    - use_setters_to_change_properties
-    - use_string_buffers
-    - use_string_in_part_of_directives
-    - use_super_parameters
-    - use_test_throws_matchers
-    - use_to_and_as_if_applicable
-    - void_checks
-
-    # Pub
-    - depend_on_referenced_packages
-    - package_names
-    - secure_pubspec_urls
-    - sort_pub_dependencies
+    - always_declare_return_types # categories: style
+    - always_put_control_body_on_new_line # categories: style
+    - always_put_required_named_parameters_first # categories: style
+    - always_specify_types # incompatibles: avoid_types_on_closure_parameters,omit_local_variable_types,omit_obvious_local_variable_types # categories: style
+    - always_use_package_imports # incompatibles: prefer_relative_imports # categories: error-prone
+    - annotate_overrides # categories: style
+    - avoid_annotating_with_dynamic # categories: brevity,style
+    - avoid_bool_literals_in_conditional_expressions # categories: brevity
+    - avoid_catches_without_on_clauses # categories: effective dart,style
+    - avoid_catching_errors # categories: style
+    - avoid_classes_with_only_static_members # categories: effective dart,language feature usage,style
+    - avoid_double_and_int_checks # categories: error-prone,web
+    - avoid_dynamic_calls # categories: binary size,error-prone
+    - avoid_empty_else # categories: brevity,error-prone
+    - avoid_equals_and_hash_code_on_mutable_classes # categories: effective dart,style
+    - avoid_escaping_inner_quotes # categories: style
+    - avoid_field_initializers_in_const_classes # categories: style
+    - avoid_final_parameters # incompatibles: prefer_final_parameters # categories: style
+    - avoid_function_literals_in_foreach_calls # categories: style
+    - avoid_implementing_value_types # categories: style
+    - avoid_init_to_null # categories: brevity,effective dart,style
+    - avoid_js_rounded_ints # categories: error-prone,web
+    - avoid_multiple_declarations_per_line # categories: style
+    - avoid_null_checks_in_equality_operators # categories: style
+    - avoid_positional_boolean_parameters # categories: effective dart,style
+    - avoid_print # categories: unintentional
+    - avoid_private_typedef_functions # categories: style
+    - avoid_redundant_argument_values # categories: brevity,style
+    - avoid_relative_lib_imports # categories: error-prone
+    - avoid_renaming_method_parameters # categories: documentation comment maintenance
+    - avoid_return_types_on_setters # categories: brevity,style
+    - avoid_returning_null_for_void # categories: style
+    - avoid_returning_this # categories: effective dart,style
+    - avoid_setters_without_getters # categories: style
+    - avoid_shadowing_type_parameters # categories: error-prone
+    - avoid_single_cascade_in_expression_statements # categories: brevity,style
+    - avoid_slow_async_io # categories: non-performant
+    - avoid_type_to_string # categories: unintentional
+    - avoid_types_as_parameter_names # categories: unintentional
+    - avoid_types_on_closure_parameters # incompatibles: always_specify_types # categories: style
+    - avoid_unused_constructor_parameters # categories: unintentional
+    - avoid_void_async # categories: style
+    - await_only_futures # categories: style
+    - camel_case_extensions # categories: effective dart,style
+    - camel_case_types # categories: effective dart,style
+    - cancel_subscriptions # categories: error-prone,memory leaks
+    - cascade_invocations # categories: brevity,language feature usage,style
+    - cast_nullable_to_non_nullable # categories: error-prone
+    - close_sinks # categories: error-prone,memory leaks
+    - collection_methods_unrelated_type # categories: unintentional
+    - combinators_ordering # categories: style
+    - comment_references # categories: documentation comment maintenance
+    - conditional_uri_does_not_exist # categories: error-prone
+    - constant_identifier_names # categories: style
+    - control_flow_in_finally # categories: error-prone
+    - curly_braces_in_flow_control_structures # categories: error-prone
+    - dangling_library_doc_comments # categories: documentation comment maintenance
+    - depend_on_referenced_packages # categories: pub
+    - deprecated_consistency # categories: style
+    - deprecated_member_use_from_same_package # categories: language feature usage
+    - directives_ordering # categories: style
+    - discarded_futures # categories: error-prone
+    - do_not_use_environment # categories: error-prone
+    - empty_catches # categories: style
+    - empty_constructor_bodies # categories: brevity,effective dart,style
+    - empty_statements # categories: error-prone
+    - eol_at_end_of_file # categories: style
+    - exhaustive_cases # categories: error-prone
+    - file_names # categories: style
+    - flutter_style_todos # categories: style
+    - hash_and_equals # categories: error-prone
+    - implementation_imports # categories: style
+    - implicit_call_tearoffs # categories: style
+    - implicit_reopen # categories: error-prone
+    - invalid_case_patterns # categories: language feature usage
+    - join_return_with_assignment # categories: brevity,style
+    - leading_newlines_in_multiline_strings # categories: style
+    - library_annotations # categories: style
+    - library_names # categories: style
+    - library_prefixes # categories: style
+    - library_private_types_in_public_api # categories: public interface
+    - lines_longer_than_80_chars # categories: style
+    - literal_only_boolean_expressions # categories: unused code
+    - matching_super_parameters # categories: style
+    - missing_whitespace_between_adjacent_strings # categories: error-prone
+    - no_adjacent_strings_in_list # categories: style
+    - no_default_cases # categories: style
+    - no_duplicate_case_values # categories: error-prone
+    - no_leading_underscores_for_library_prefixes # categories: style
+    - no_leading_underscores_for_local_identifiers # categories: style
+    - no_literal_bool_comparisons # categories: effective dart,style
+    - no_runtimeType_toString # categories: non-performant
+    - non_constant_identifier_names # categories: style
+    - noop_primitive_operations # categories: style
+    - null_check_on_nullable_type_parameter # categories: style
+    - null_closures # categories: error-prone
+    - omit_local_variable_types # incompatibles: always_specify_types # categories: style
+    - one_member_abstracts # categories: effective dart,language feature usage,style
+    - only_throw_errors # categories: style
+    - overridden_fields # categories: style
+    - package_api_docs # categories: effective dart,public interface
+    - package_names # categories: style
+    - package_prefixed_library_names # categories: style
+    - parameter_assignments # categories: style
+    - prefer_adjacent_string_concatenation # categories: style
+    - prefer_asserts_in_initializer_lists # categories: style
+    - prefer_asserts_with_message # categories: style
+    - prefer_collection_literals # categories: brevity,style
+    - prefer_conditional_assignment # categories: brevity,style
+    - prefer_const_constructors # categories: style
+    - prefer_const_constructors_in_immutables # categories: style
+    - prefer_const_declarations # categories: style
+    - prefer_const_literals_to_create_immutables # categories: style
+    - prefer_constructors_over_static_methods # categories: style
+    - prefer_contains # categories: style
+    - prefer_double_quotes # incompatibles: prefer_single_quotes # categories: style
+    - prefer_expression_function_bodies # categories: brevity,style
+    - prefer_final_fields # categories: effective dart,style
+    - prefer_final_in_for_each # categories: style
+    - prefer_final_locals # incompatibles: unnecessary_final # categories: style
+    - prefer_final_parameters # incompatibles: unnecessary_final,avoid_final_parameters # categories: style
+    - prefer_for_elements_to_map_fromIterable # categories: brevity,style
+    - prefer_foreach # categories: style
+    - prefer_function_declarations_over_variables # categories: effective dart,style
+    - prefer_generic_function_type_aliases # categories: style
+    - prefer_if_elements_to_conditional_expressions # categories: brevity,style
+    - prefer_if_null_operators # categories: brevity,style
+    - prefer_initializing_formals # categories: brevity,style
+    - prefer_inlined_adds # categories: brevity,style
+    - prefer_int_literals # categories: style
+    - prefer_interpolation_to_compose_strings # categories: style
+    - prefer_is_empty # categories: style
+    - prefer_is_not_empty # categories: style
+    - prefer_is_not_operator # categories: brevity,style
+    - prefer_iterable_whereType # categories: style
+    - prefer_mixin # categories: language feature usage,style
+    - prefer_null_aware_method_calls # categories: brevity,style
+    - prefer_null_aware_operators # categories: brevity,style
+    - prefer_relative_imports # incompatibles: always_use_package_imports # categories: error-prone
+    - prefer_single_quotes # incompatibles: prefer_double_quotes # categories: style
+    - prefer_spread_collections # categories: brevity,style
+    - prefer_typing_uninitialized_variables # categories: error-prone,unintentional
+    - prefer_void_to_null # categories: error-prone
+    - provide_deprecation_message # categories: public interface
+    - public_member_api_docs # categories: public interface,style
+    - recursive_getters # categories: error-prone,unintentional
+    - require_trailing_commas # categories: style
+    - secure_pubspec_urls # categories: pub
+    - slash_for_doc_comments # categories: effective dart,style
+    - sort_constructors_first # categories: style
+    - sort_pub_dependencies # categories: pub
+    - sort_unnamed_constructors_first # categories: style
+    - test_types_in_equals # categories: error-prone
+    - throw_in_finally # categories: error-prone
+    - tighten_type_of_initializing_formals # categories: style
+    - type_annotate_public_apis # categories: effective dart,public interface
+    - type_init_formals # categories: effective dart,style
+    - type_literal_in_constant_pattern # categories: style
+    - unawaited_futures # categories: style
+    - unnecessary_await_in_return # categories: style
+    - unnecessary_brace_in_string_interps # categories: brevity,style
+    - unnecessary_breaks # categories: brevity,style
+    - unnecessary_const # categories: brevity,style
+    - unnecessary_constructor_name # categories: brevity,style
+    - unnecessary_final # incompatibles: prefer_final_locals,prefer_final_parameters # categories: effective dart,style
+    - unnecessary_getters_setters # categories: effective dart,style
+    - unnecessary_lambdas # categories: style
+    - unnecessary_late # categories: style
+    - unnecessary_library_directive # categories: brevity
+    - unnecessary_new # categories: brevity,language feature usage,style
+    - unnecessary_null_aware_assignments # categories: brevity,effective dart,style
+    - unnecessary_null_aware_operator_on_extension_on_nullable # categories: style
+    - unnecessary_null_checks # categories: brevity,style
+    - unnecessary_null_in_if_null_operators # categories: style
+    - unnecessary_nullable_for_final_variable_declarations # categories: style
+    - unnecessary_overrides # categories: style
+    - unnecessary_parenthesis # categories: brevity,style
+    - unnecessary_raw_strings # categories: brevity,style
+    - unnecessary_statements # categories: brevity,unintentional
+    - unnecessary_string_escapes # categories: brevity,style
+    - unnecessary_string_interpolations # categories: brevity,style
+    - unnecessary_this # categories: brevity,effective dart,style
+    - unnecessary_to_list_in_spreads # categories: brevity
+    - unreachable_from_main # categories: unused code
+    - unrelated_type_equality_checks # categories: unintentional
+    - unsafe_html # categories: errors
+    - use_enums # categories: style
+    - use_function_type_syntax_for_parameters # categories: style
+    - use_if_null_to_convert_nulls_to_bools # categories: effective dart,style
+    - use_is_even_rather_than_modulo # categories: style
+    - use_late_for_private_fields_and_variables # categories: style
+    - use_named_constants # categories: style
+    - use_raw_strings # categories: style
+    - use_rethrow_when_possible # categories: brevity,effective dart
+    - use_setters_to_change_properties # categories: style
+    - use_string_buffers # categories: non-performant
+    - use_string_in_part_of_directives # categories: effective dart,style
+    - use_super_parameters # categories: brevity
+    - use_test_throws_matchers # categories: style
+    - use_to_and_as_if_applicable # categories: effective dart,style
+    - valid_regexps # categories: unintentional
+    - void_checks # categories: style

--- a/packages/yumemi_lints/lib/dart/3.1/all.yaml
+++ b/packages/yumemi_lints/lib/dart/3.1/all.yaml
@@ -2,212 +2,207 @@
 
 linter:
   rules:
-    # Errors
-    - always_use_package_imports # incompatibles: prefer_relative_imports
-    - avoid_dynamic_calls
-    - avoid_empty_else
-    - avoid_print
-    - avoid_relative_lib_imports
-    - avoid_slow_async_io
-    - avoid_type_to_string
-    - avoid_types_as_parameter_names
-    - cancel_subscriptions
-    - close_sinks
-    - collection_methods_unrelated_type
-    - comment_references
-    - control_flow_in_finally
-    - deprecated_member_use_from_same_package
-    - discarded_futures
-    - empty_statements
-    - hash_and_equals
-    - implicit_reopen
-    - invalid_case_patterns
-    - literal_only_boolean_expressions
-    - no_adjacent_strings_in_list
-    - no_duplicate_case_values
-    - no_self_assignments
-    - no_wildcard_variable_uses
-    - prefer_relative_imports # incompatibles: always_use_package_imports
-    - prefer_void_to_null
-    - test_types_in_equals
-    - throw_in_finally
-    - unnecessary_statements
-    - unrelated_type_equality_checks
-    - unsafe_html
-    - valid_regexps
-
-    # Style
-    - always_declare_return_types
-    - always_put_control_body_on_new_line
-    - always_put_required_named_parameters_first
-    - always_specify_types # incompatibles: avoid_types_on_closure_parameters,omit_local_variable_types
-    - annotate_overrides
-    - avoid_annotating_with_dynamic
-    - avoid_bool_literals_in_conditional_expressions
-    - avoid_catches_without_on_clauses
-    - avoid_catching_errors
-    - avoid_classes_with_only_static_members
-    - avoid_double_and_int_checks
-    - avoid_equals_and_hash_code_on_mutable_classes
-    - avoid_escaping_inner_quotes
-    - avoid_field_initializers_in_const_classes
-    - avoid_final_parameters # incompatibles: prefer_final_parameters
-    - avoid_function_literals_in_foreach_calls
-    - avoid_implementing_value_types
-    - avoid_init_to_null
-    - avoid_js_rounded_ints
-    - avoid_multiple_declarations_per_line
-    - avoid_null_checks_in_equality_operators
-    - avoid_positional_boolean_parameters
-    - avoid_private_typedef_functions
-    - avoid_redundant_argument_values
-    - avoid_renaming_method_parameters
-    - avoid_return_types_on_setters
-    - avoid_returning_null_for_void
-    - avoid_returning_this
-    - avoid_setters_without_getters
-    - avoid_shadowing_type_parameters
-    - avoid_single_cascade_in_expression_statements
-    - avoid_types_on_closure_parameters # incompatibles: always_specify_types
-    - avoid_unused_constructor_parameters
-    - avoid_void_async
-    - await_only_futures
-    - camel_case_extensions
-    - camel_case_types
-    - cascade_invocations
-    - cast_nullable_to_non_nullable
-    - combinators_ordering
-    - conditional_uri_does_not_exist
-    - constant_identifier_names
-    - curly_braces_in_flow_control_structures
-    - dangling_library_doc_comments
-    - deprecated_consistency
-    - directives_ordering
-    - do_not_use_environment
-    - empty_catches
-    - empty_constructor_bodies
-    - eol_at_end_of_file
-    - exhaustive_cases
-    - file_names
-    - flutter_style_todos
-    - implementation_imports
-    - implicit_call_tearoffs
-    - join_return_with_assignment
-    - leading_newlines_in_multiline_strings
-    - library_annotations
-    - library_names
-    - library_prefixes
-    - library_private_types_in_public_api
-    - lines_longer_than_80_chars
-    - matching_super_parameters
-    - missing_whitespace_between_adjacent_strings
-    - no_default_cases
-    - no_leading_underscores_for_library_prefixes
-    - no_leading_underscores_for_local_identifiers
-    - no_literal_bool_comparisons
-    - no_runtimeType_toString
-    - non_constant_identifier_names
-    - noop_primitive_operations
-    - null_check_on_nullable_type_parameter
-    - null_closures
-    - omit_local_variable_types # incompatibles: always_specify_types
-    - one_member_abstracts
-    - only_throw_errors
-    - overridden_fields
-    - package_api_docs
-    - package_prefixed_library_names
-    - parameter_assignments
-    - prefer_adjacent_string_concatenation
-    - prefer_asserts_in_initializer_lists
-    - prefer_asserts_with_message
-    - prefer_collection_literals
-    - prefer_conditional_assignment
-    - prefer_const_constructors
-    - prefer_const_constructors_in_immutables
-    - prefer_const_declarations
-    - prefer_const_literals_to_create_immutables
-    - prefer_constructors_over_static_methods
-    - prefer_contains
-    - prefer_double_quotes # incompatibles: prefer_single_quotes
-    - prefer_expression_function_bodies
-    - prefer_final_fields
-    - prefer_final_in_for_each
-    - prefer_final_locals # incompatibles: unnecessary_final
-    - prefer_final_parameters # incompatibles: unnecessary_final,avoid_final_parameters
-    - prefer_for_elements_to_map_fromIterable
-    - prefer_foreach
-    - prefer_function_declarations_over_variables
-    - prefer_generic_function_type_aliases
-    - prefer_if_elements_to_conditional_expressions
-    - prefer_if_null_operators
-    - prefer_initializing_formals
-    - prefer_inlined_adds
-    - prefer_int_literals
-    - prefer_interpolation_to_compose_strings
-    - prefer_is_empty
-    - prefer_is_not_empty
-    - prefer_is_not_operator
-    - prefer_iterable_whereType
-    - prefer_mixin
-    - prefer_null_aware_method_calls
-    - prefer_null_aware_operators
-    - prefer_single_quotes # incompatibles: prefer_double_quotes
-    - prefer_spread_collections
-    - prefer_typing_uninitialized_variables
-    - provide_deprecation_message
-    - public_member_api_docs
-    - recursive_getters
-    - require_trailing_commas
-    - slash_for_doc_comments
-    - sort_constructors_first
-    - sort_unnamed_constructors_first
-    - tighten_type_of_initializing_formals
-    - type_annotate_public_apis
-    - type_init_formals
-    - type_literal_in_constant_pattern
-    - unawaited_futures
-    - unnecessary_await_in_return
-    - unnecessary_brace_in_string_interps
-    - unnecessary_breaks
-    - unnecessary_const
-    - unnecessary_constructor_name
-    - unnecessary_final # incompatibles: prefer_final_locals,prefer_final_parameters
-    - unnecessary_getters_setters
-    - unnecessary_lambdas
-    - unnecessary_late
-    - unnecessary_library_directive
-    - unnecessary_new
-    - unnecessary_null_aware_assignments
-    - unnecessary_null_aware_operator_on_extension_on_nullable
-    - unnecessary_null_checks
-    - unnecessary_null_in_if_null_operators
-    - unnecessary_nullable_for_final_variable_declarations
-    - unnecessary_overrides
-    - unnecessary_parenthesis
-    - unnecessary_raw_strings
-    - unnecessary_string_escapes
-    - unnecessary_string_interpolations
-    - unnecessary_this
-    - unnecessary_to_list_in_spreads
-    - unreachable_from_main
-    - use_enums
-    - use_function_type_syntax_for_parameters
-    - use_if_null_to_convert_nulls_to_bools
-    - use_is_even_rather_than_modulo
-    - use_late_for_private_fields_and_variables
-    - use_named_constants
-    - use_raw_strings
-    - use_rethrow_when_possible
-    - use_setters_to_change_properties
-    - use_string_buffers
-    - use_string_in_part_of_directives
-    - use_super_parameters
-    - use_test_throws_matchers
-    - use_to_and_as_if_applicable
-    - void_checks
-
-    # Pub
-    - depend_on_referenced_packages
-    - package_names
-    - secure_pubspec_urls
-    - sort_pub_dependencies
+    - always_declare_return_types # categories: style
+    - always_put_control_body_on_new_line # categories: style
+    - always_put_required_named_parameters_first # categories: style
+    - always_specify_types # incompatibles: avoid_types_on_closure_parameters,omit_local_variable_types,omit_obvious_local_variable_types # categories: style
+    - always_use_package_imports # incompatibles: prefer_relative_imports # categories: error-prone
+    - annotate_overrides # categories: style
+    - avoid_annotating_with_dynamic # categories: brevity,style
+    - avoid_bool_literals_in_conditional_expressions # categories: brevity
+    - avoid_catches_without_on_clauses # categories: effective dart,style
+    - avoid_catching_errors # categories: style
+    - avoid_classes_with_only_static_members # categories: effective dart,language feature usage,style
+    - avoid_double_and_int_checks # categories: error-prone,web
+    - avoid_dynamic_calls # categories: binary size,error-prone
+    - avoid_empty_else # categories: brevity,error-prone
+    - avoid_equals_and_hash_code_on_mutable_classes # categories: effective dart,style
+    - avoid_escaping_inner_quotes # categories: style
+    - avoid_field_initializers_in_const_classes # categories: style
+    - avoid_final_parameters # incompatibles: prefer_final_parameters # categories: style
+    - avoid_function_literals_in_foreach_calls # categories: style
+    - avoid_implementing_value_types # categories: style
+    - avoid_init_to_null # categories: brevity,effective dart,style
+    - avoid_js_rounded_ints # categories: error-prone,web
+    - avoid_multiple_declarations_per_line # categories: style
+    - avoid_null_checks_in_equality_operators # categories: style
+    - avoid_positional_boolean_parameters # categories: effective dart,style
+    - avoid_print # categories: unintentional
+    - avoid_private_typedef_functions # categories: style
+    - avoid_redundant_argument_values # categories: brevity,style
+    - avoid_relative_lib_imports # categories: error-prone
+    - avoid_renaming_method_parameters # categories: documentation comment maintenance
+    - avoid_return_types_on_setters # categories: brevity,style
+    - avoid_returning_null_for_void # categories: style
+    - avoid_returning_this # categories: effective dart,style
+    - avoid_setters_without_getters # categories: style
+    - avoid_shadowing_type_parameters # categories: error-prone
+    - avoid_single_cascade_in_expression_statements # categories: brevity,style
+    - avoid_slow_async_io # categories: non-performant
+    - avoid_type_to_string # categories: unintentional
+    - avoid_types_as_parameter_names # categories: unintentional
+    - avoid_types_on_closure_parameters # incompatibles: always_specify_types # categories: style
+    - avoid_unused_constructor_parameters # categories: unintentional
+    - avoid_void_async # categories: style
+    - await_only_futures # categories: style
+    - camel_case_extensions # categories: effective dart,style
+    - camel_case_types # categories: effective dart,style
+    - cancel_subscriptions # categories: error-prone,memory leaks
+    - cascade_invocations # categories: brevity,language feature usage,style
+    - cast_nullable_to_non_nullable # categories: error-prone
+    - close_sinks # categories: error-prone,memory leaks
+    - collection_methods_unrelated_type # categories: unintentional
+    - combinators_ordering # categories: style
+    - comment_references # categories: documentation comment maintenance
+    - conditional_uri_does_not_exist # categories: error-prone
+    - constant_identifier_names # categories: style
+    - control_flow_in_finally # categories: error-prone
+    - curly_braces_in_flow_control_structures # categories: error-prone
+    - dangling_library_doc_comments # categories: documentation comment maintenance
+    - depend_on_referenced_packages # categories: pub
+    - deprecated_consistency # categories: style
+    - deprecated_member_use_from_same_package # categories: language feature usage
+    - directives_ordering # categories: style
+    - discarded_futures # categories: error-prone
+    - do_not_use_environment # categories: error-prone
+    - empty_catches # categories: style
+    - empty_constructor_bodies # categories: brevity,effective dart,style
+    - empty_statements # categories: error-prone
+    - eol_at_end_of_file # categories: style
+    - exhaustive_cases # categories: error-prone
+    - file_names # categories: style
+    - flutter_style_todos # categories: style
+    - hash_and_equals # categories: error-prone
+    - implementation_imports # categories: style
+    - implicit_call_tearoffs # categories: style
+    - implicit_reopen # categories: error-prone
+    - invalid_case_patterns # categories: language feature usage
+    - join_return_with_assignment # categories: brevity,style
+    - leading_newlines_in_multiline_strings # categories: style
+    - library_annotations # categories: style
+    - library_names # categories: style
+    - library_prefixes # categories: style
+    - library_private_types_in_public_api # categories: public interface
+    - lines_longer_than_80_chars # categories: style
+    - literal_only_boolean_expressions # categories: unused code
+    - matching_super_parameters # categories: style
+    - missing_whitespace_between_adjacent_strings # categories: error-prone
+    - no_adjacent_strings_in_list # categories: style
+    - no_default_cases # categories: style
+    - no_duplicate_case_values # categories: error-prone
+    - no_leading_underscores_for_library_prefixes # categories: style
+    - no_leading_underscores_for_local_identifiers # categories: style
+    - no_literal_bool_comparisons # categories: effective dart,style
+    - no_runtimeType_toString # categories: non-performant
+    - no_self_assignments # categories: unintentional
+    - no_wildcard_variable_uses # categories: language feature usage,unintentional
+    - non_constant_identifier_names # categories: style
+    - noop_primitive_operations # categories: style
+    - null_check_on_nullable_type_parameter # categories: style
+    - null_closures # categories: error-prone
+    - omit_local_variable_types # incompatibles: always_specify_types # categories: style
+    - one_member_abstracts # categories: effective dart,language feature usage,style
+    - only_throw_errors # categories: style
+    - overridden_fields # categories: style
+    - package_api_docs # categories: effective dart,public interface
+    - package_names # categories: style
+    - package_prefixed_library_names # categories: style
+    - parameter_assignments # categories: style
+    - prefer_adjacent_string_concatenation # categories: style
+    - prefer_asserts_in_initializer_lists # categories: style
+    - prefer_asserts_with_message # categories: style
+    - prefer_collection_literals # categories: brevity,style
+    - prefer_conditional_assignment # categories: brevity,style
+    - prefer_const_constructors # categories: style
+    - prefer_const_constructors_in_immutables # categories: style
+    - prefer_const_declarations # categories: style
+    - prefer_const_literals_to_create_immutables # categories: style
+    - prefer_constructors_over_static_methods # categories: style
+    - prefer_contains # categories: style
+    - prefer_double_quotes # incompatibles: prefer_single_quotes # categories: style
+    - prefer_expression_function_bodies # categories: brevity,style
+    - prefer_final_fields # categories: effective dart,style
+    - prefer_final_in_for_each # categories: style
+    - prefer_final_locals # incompatibles: unnecessary_final # categories: style
+    - prefer_final_parameters # incompatibles: unnecessary_final,avoid_final_parameters # categories: style
+    - prefer_for_elements_to_map_fromIterable # categories: brevity,style
+    - prefer_foreach # categories: style
+    - prefer_function_declarations_over_variables # categories: effective dart,style
+    - prefer_generic_function_type_aliases # categories: style
+    - prefer_if_elements_to_conditional_expressions # categories: brevity,style
+    - prefer_if_null_operators # categories: brevity,style
+    - prefer_initializing_formals # categories: brevity,style
+    - prefer_inlined_adds # categories: brevity,style
+    - prefer_int_literals # categories: style
+    - prefer_interpolation_to_compose_strings # categories: style
+    - prefer_is_empty # categories: style
+    - prefer_is_not_empty # categories: style
+    - prefer_is_not_operator # categories: brevity,style
+    - prefer_iterable_whereType # categories: style
+    - prefer_mixin # categories: language feature usage,style
+    - prefer_null_aware_method_calls # categories: brevity,style
+    - prefer_null_aware_operators # categories: brevity,style
+    - prefer_relative_imports # incompatibles: always_use_package_imports # categories: error-prone
+    - prefer_single_quotes # incompatibles: prefer_double_quotes # categories: style
+    - prefer_spread_collections # categories: brevity,style
+    - prefer_typing_uninitialized_variables # categories: error-prone,unintentional
+    - prefer_void_to_null # categories: error-prone
+    - provide_deprecation_message # categories: public interface
+    - public_member_api_docs # categories: public interface,style
+    - recursive_getters # categories: error-prone,unintentional
+    - require_trailing_commas # categories: style
+    - secure_pubspec_urls # categories: pub
+    - slash_for_doc_comments # categories: effective dart,style
+    - sort_constructors_first # categories: style
+    - sort_pub_dependencies # categories: pub
+    - sort_unnamed_constructors_first # categories: style
+    - test_types_in_equals # categories: error-prone
+    - throw_in_finally # categories: error-prone
+    - tighten_type_of_initializing_formals # categories: style
+    - type_annotate_public_apis # categories: effective dart,public interface
+    - type_init_formals # categories: effective dart,style
+    - type_literal_in_constant_pattern # categories: style
+    - unawaited_futures # categories: style
+    - unnecessary_await_in_return # categories: style
+    - unnecessary_brace_in_string_interps # categories: brevity,style
+    - unnecessary_breaks # categories: brevity,style
+    - unnecessary_const # categories: brevity,style
+    - unnecessary_constructor_name # categories: brevity,style
+    - unnecessary_final # incompatibles: prefer_final_locals,prefer_final_parameters # categories: effective dart,style
+    - unnecessary_getters_setters # categories: effective dart,style
+    - unnecessary_lambdas # categories: style
+    - unnecessary_late # categories: style
+    - unnecessary_library_directive # categories: brevity
+    - unnecessary_new # categories: brevity,language feature usage,style
+    - unnecessary_null_aware_assignments # categories: brevity,effective dart,style
+    - unnecessary_null_aware_operator_on_extension_on_nullable # categories: style
+    - unnecessary_null_checks # categories: brevity,style
+    - unnecessary_null_in_if_null_operators # categories: style
+    - unnecessary_nullable_for_final_variable_declarations # categories: style
+    - unnecessary_overrides # categories: style
+    - unnecessary_parenthesis # categories: brevity,style
+    - unnecessary_raw_strings # categories: brevity,style
+    - unnecessary_statements # categories: brevity,unintentional
+    - unnecessary_string_escapes # categories: brevity,style
+    - unnecessary_string_interpolations # categories: brevity,style
+    - unnecessary_this # categories: brevity,effective dart,style
+    - unnecessary_to_list_in_spreads # categories: brevity
+    - unreachable_from_main # categories: unused code
+    - unrelated_type_equality_checks # categories: unintentional
+    - unsafe_html # categories: errors
+    - use_enums # categories: style
+    - use_function_type_syntax_for_parameters # categories: style
+    - use_if_null_to_convert_nulls_to_bools # categories: effective dart,style
+    - use_is_even_rather_than_modulo # categories: style
+    - use_late_for_private_fields_and_variables # categories: style
+    - use_named_constants # categories: style
+    - use_raw_strings # categories: style
+    - use_rethrow_when_possible # categories: brevity,effective dart
+    - use_setters_to_change_properties # categories: style
+    - use_string_buffers # categories: non-performant
+    - use_string_in_part_of_directives # categories: effective dart,style
+    - use_super_parameters # categories: brevity
+    - use_test_throws_matchers # categories: style
+    - use_to_and_as_if_applicable # categories: effective dart,style
+    - valid_regexps # categories: unintentional
+    - void_checks # categories: style

--- a/packages/yumemi_lints/lib/dart/3.2/all.yaml
+++ b/packages/yumemi_lints/lib/dart/3.2/all.yaml
@@ -2,213 +2,208 @@
 
 linter:
   rules:
-    # Errors
-    - always_use_package_imports # incompatibles: prefer_relative_imports
-    - avoid_dynamic_calls
-    - avoid_empty_else
-    - avoid_print
-    - avoid_relative_lib_imports
-    - avoid_slow_async_io
-    - avoid_type_to_string
-    - avoid_types_as_parameter_names
-    - cancel_subscriptions
-    - close_sinks
-    - collection_methods_unrelated_type
-    - comment_references
-    - control_flow_in_finally
-    - deprecated_member_use_from_same_package
-    - discarded_futures
-    - empty_statements
-    - hash_and_equals
-    - implicit_reopen
-    - invalid_case_patterns
-    - literal_only_boolean_expressions
-    - no_adjacent_strings_in_list
-    - no_duplicate_case_values
-    - no_self_assignments
-    - no_wildcard_variable_uses
-    - prefer_relative_imports # incompatibles: always_use_package_imports
-    - prefer_void_to_null
-    - test_types_in_equals
-    - throw_in_finally
-    - unnecessary_statements
-    - unrelated_type_equality_checks
-    - unsafe_html
-    - valid_regexps
-
-    # Style
-    - always_declare_return_types
-    - always_put_control_body_on_new_line
-    - always_put_required_named_parameters_first
-    - always_specify_types # incompatibles: avoid_types_on_closure_parameters,omit_local_variable_types
-    - annotate_overrides
-    - annotate_redeclares
-    - avoid_annotating_with_dynamic
-    - avoid_bool_literals_in_conditional_expressions
-    - avoid_catches_without_on_clauses
-    - avoid_catching_errors
-    - avoid_classes_with_only_static_members
-    - avoid_double_and_int_checks
-    - avoid_equals_and_hash_code_on_mutable_classes
-    - avoid_escaping_inner_quotes
-    - avoid_field_initializers_in_const_classes
-    - avoid_final_parameters # incompatibles: prefer_final_parameters
-    - avoid_function_literals_in_foreach_calls
-    - avoid_implementing_value_types
-    - avoid_init_to_null
-    - avoid_js_rounded_ints
-    - avoid_multiple_declarations_per_line
-    - avoid_null_checks_in_equality_operators
-    - avoid_positional_boolean_parameters
-    - avoid_private_typedef_functions
-    - avoid_redundant_argument_values
-    - avoid_renaming_method_parameters
-    - avoid_return_types_on_setters
-    - avoid_returning_null_for_void
-    - avoid_returning_this
-    - avoid_setters_without_getters
-    - avoid_shadowing_type_parameters
-    - avoid_single_cascade_in_expression_statements
-    - avoid_types_on_closure_parameters # incompatibles: always_specify_types
-    - avoid_unused_constructor_parameters
-    - avoid_void_async
-    - await_only_futures
-    - camel_case_extensions
-    - camel_case_types
-    - cascade_invocations
-    - cast_nullable_to_non_nullable
-    - combinators_ordering
-    - conditional_uri_does_not_exist
-    - constant_identifier_names
-    - curly_braces_in_flow_control_structures
-    - dangling_library_doc_comments
-    - deprecated_consistency
-    - directives_ordering
-    - do_not_use_environment
-    - empty_catches
-    - empty_constructor_bodies
-    - eol_at_end_of_file
-    - exhaustive_cases
-    - file_names
-    - flutter_style_todos
-    - implementation_imports
-    - implicit_call_tearoffs
-    - join_return_with_assignment
-    - leading_newlines_in_multiline_strings
-    - library_annotations
-    - library_names
-    - library_prefixes
-    - library_private_types_in_public_api
-    - lines_longer_than_80_chars
-    - matching_super_parameters
-    - missing_whitespace_between_adjacent_strings
-    - no_default_cases
-    - no_leading_underscores_for_library_prefixes
-    - no_leading_underscores_for_local_identifiers
-    - no_literal_bool_comparisons
-    - no_runtimeType_toString
-    - non_constant_identifier_names
-    - noop_primitive_operations
-    - null_check_on_nullable_type_parameter
-    - null_closures
-    - omit_local_variable_types # incompatibles: always_specify_types
-    - one_member_abstracts
-    - only_throw_errors
-    - overridden_fields
-    - package_api_docs
-    - package_prefixed_library_names
-    - parameter_assignments
-    - prefer_adjacent_string_concatenation
-    - prefer_asserts_in_initializer_lists
-    - prefer_asserts_with_message
-    - prefer_collection_literals
-    - prefer_conditional_assignment
-    - prefer_const_constructors
-    - prefer_const_constructors_in_immutables
-    - prefer_const_declarations
-    - prefer_const_literals_to_create_immutables
-    - prefer_constructors_over_static_methods
-    - prefer_contains
-    - prefer_double_quotes # incompatibles: prefer_single_quotes
-    - prefer_expression_function_bodies
-    - prefer_final_fields
-    - prefer_final_in_for_each
-    - prefer_final_locals # incompatibles: unnecessary_final
-    - prefer_final_parameters # incompatibles: unnecessary_final,avoid_final_parameters
-    - prefer_for_elements_to_map_fromIterable
-    - prefer_foreach
-    - prefer_function_declarations_over_variables
-    - prefer_generic_function_type_aliases
-    - prefer_if_elements_to_conditional_expressions
-    - prefer_if_null_operators
-    - prefer_initializing_formals
-    - prefer_inlined_adds
-    - prefer_int_literals
-    - prefer_interpolation_to_compose_strings
-    - prefer_is_empty
-    - prefer_is_not_empty
-    - prefer_is_not_operator
-    - prefer_iterable_whereType
-    - prefer_mixin
-    - prefer_null_aware_method_calls
-    - prefer_null_aware_operators
-    - prefer_single_quotes # incompatibles: prefer_double_quotes
-    - prefer_spread_collections
-    - prefer_typing_uninitialized_variables
-    - provide_deprecation_message
-    - public_member_api_docs
-    - recursive_getters
-    - require_trailing_commas
-    - slash_for_doc_comments
-    - sort_constructors_first
-    - sort_unnamed_constructors_first
-    - tighten_type_of_initializing_formals
-    - type_annotate_public_apis
-    - type_init_formals
-    - type_literal_in_constant_pattern
-    - unawaited_futures
-    - unnecessary_await_in_return
-    - unnecessary_brace_in_string_interps
-    - unnecessary_breaks
-    - unnecessary_const
-    - unnecessary_constructor_name
-    - unnecessary_final # incompatibles: prefer_final_locals,prefer_final_parameters
-    - unnecessary_getters_setters
-    - unnecessary_lambdas
-    - unnecessary_late
-    - unnecessary_library_directive
-    - unnecessary_new
-    - unnecessary_null_aware_assignments
-    - unnecessary_null_aware_operator_on_extension_on_nullable
-    - unnecessary_null_checks
-    - unnecessary_null_in_if_null_operators
-    - unnecessary_nullable_for_final_variable_declarations
-    - unnecessary_overrides
-    - unnecessary_parenthesis
-    - unnecessary_raw_strings
-    - unnecessary_string_escapes
-    - unnecessary_string_interpolations
-    - unnecessary_this
-    - unnecessary_to_list_in_spreads
-    - unreachable_from_main
-    - use_enums
-    - use_function_type_syntax_for_parameters
-    - use_if_null_to_convert_nulls_to_bools
-    - use_is_even_rather_than_modulo
-    - use_late_for_private_fields_and_variables
-    - use_named_constants
-    - use_raw_strings
-    - use_rethrow_when_possible
-    - use_setters_to_change_properties
-    - use_string_buffers
-    - use_string_in_part_of_directives
-    - use_super_parameters
-    - use_test_throws_matchers
-    - use_to_and_as_if_applicable
-    - void_checks
-
-    # Pub
-    - depend_on_referenced_packages
-    - package_names
-    - secure_pubspec_urls
-    - sort_pub_dependencies
+    - always_declare_return_types # categories: style
+    - always_put_control_body_on_new_line # categories: style
+    - always_put_required_named_parameters_first # categories: style
+    - always_specify_types # incompatibles: avoid_types_on_closure_parameters,omit_local_variable_types,omit_obvious_local_variable_types # categories: style
+    - always_use_package_imports # incompatibles: prefer_relative_imports # categories: error-prone
+    - annotate_overrides # categories: style
+    - annotate_redeclares # categories: style
+    - avoid_annotating_with_dynamic # categories: brevity,style
+    - avoid_bool_literals_in_conditional_expressions # categories: brevity
+    - avoid_catches_without_on_clauses # categories: effective dart,style
+    - avoid_catching_errors # categories: style
+    - avoid_classes_with_only_static_members # categories: effective dart,language feature usage,style
+    - avoid_double_and_int_checks # categories: error-prone,web
+    - avoid_dynamic_calls # categories: binary size,error-prone
+    - avoid_empty_else # categories: brevity,error-prone
+    - avoid_equals_and_hash_code_on_mutable_classes # categories: effective dart,style
+    - avoid_escaping_inner_quotes # categories: style
+    - avoid_field_initializers_in_const_classes # categories: style
+    - avoid_final_parameters # incompatibles: prefer_final_parameters # categories: style
+    - avoid_function_literals_in_foreach_calls # categories: style
+    - avoid_implementing_value_types # categories: style
+    - avoid_init_to_null # categories: brevity,effective dart,style
+    - avoid_js_rounded_ints # categories: error-prone,web
+    - avoid_multiple_declarations_per_line # categories: style
+    - avoid_null_checks_in_equality_operators # categories: style
+    - avoid_positional_boolean_parameters # categories: effective dart,style
+    - avoid_print # categories: unintentional
+    - avoid_private_typedef_functions # categories: style
+    - avoid_redundant_argument_values # categories: brevity,style
+    - avoid_relative_lib_imports # categories: error-prone
+    - avoid_renaming_method_parameters # categories: documentation comment maintenance
+    - avoid_return_types_on_setters # categories: brevity,style
+    - avoid_returning_null_for_void # categories: style
+    - avoid_returning_this # categories: effective dart,style
+    - avoid_setters_without_getters # categories: style
+    - avoid_shadowing_type_parameters # categories: error-prone
+    - avoid_single_cascade_in_expression_statements # categories: brevity,style
+    - avoid_slow_async_io # categories: non-performant
+    - avoid_type_to_string # categories: unintentional
+    - avoid_types_as_parameter_names # categories: unintentional
+    - avoid_types_on_closure_parameters # incompatibles: always_specify_types # categories: style
+    - avoid_unused_constructor_parameters # categories: unintentional
+    - avoid_void_async # categories: style
+    - await_only_futures # categories: style
+    - camel_case_extensions # categories: effective dart,style
+    - camel_case_types # categories: effective dart,style
+    - cancel_subscriptions # categories: error-prone,memory leaks
+    - cascade_invocations # categories: brevity,language feature usage,style
+    - cast_nullable_to_non_nullable # categories: error-prone
+    - close_sinks # categories: error-prone,memory leaks
+    - collection_methods_unrelated_type # categories: unintentional
+    - combinators_ordering # categories: style
+    - comment_references # categories: documentation comment maintenance
+    - conditional_uri_does_not_exist # categories: error-prone
+    - constant_identifier_names # categories: style
+    - control_flow_in_finally # categories: error-prone
+    - curly_braces_in_flow_control_structures # categories: error-prone
+    - dangling_library_doc_comments # categories: documentation comment maintenance
+    - depend_on_referenced_packages # categories: pub
+    - deprecated_consistency # categories: style
+    - deprecated_member_use_from_same_package # categories: language feature usage
+    - directives_ordering # categories: style
+    - discarded_futures # categories: error-prone
+    - do_not_use_environment # categories: error-prone
+    - empty_catches # categories: style
+    - empty_constructor_bodies # categories: brevity,effective dart,style
+    - empty_statements # categories: error-prone
+    - eol_at_end_of_file # categories: style
+    - exhaustive_cases # categories: error-prone
+    - file_names # categories: style
+    - flutter_style_todos # categories: style
+    - hash_and_equals # categories: error-prone
+    - implementation_imports # categories: style
+    - implicit_call_tearoffs # categories: style
+    - implicit_reopen # categories: error-prone
+    - invalid_case_patterns # categories: language feature usage
+    - join_return_with_assignment # categories: brevity,style
+    - leading_newlines_in_multiline_strings # categories: style
+    - library_annotations # categories: style
+    - library_names # categories: style
+    - library_prefixes # categories: style
+    - library_private_types_in_public_api # categories: public interface
+    - lines_longer_than_80_chars # categories: style
+    - literal_only_boolean_expressions # categories: unused code
+    - matching_super_parameters # categories: style
+    - missing_whitespace_between_adjacent_strings # categories: error-prone
+    - no_adjacent_strings_in_list # categories: style
+    - no_default_cases # categories: style
+    - no_duplicate_case_values # categories: error-prone
+    - no_leading_underscores_for_library_prefixes # categories: style
+    - no_leading_underscores_for_local_identifiers # categories: style
+    - no_literal_bool_comparisons # categories: effective dart,style
+    - no_runtimeType_toString # categories: non-performant
+    - no_self_assignments # categories: unintentional
+    - no_wildcard_variable_uses # categories: language feature usage,unintentional
+    - non_constant_identifier_names # categories: style
+    - noop_primitive_operations # categories: style
+    - null_check_on_nullable_type_parameter # categories: style
+    - null_closures # categories: error-prone
+    - omit_local_variable_types # incompatibles: always_specify_types # categories: style
+    - one_member_abstracts # categories: effective dart,language feature usage,style
+    - only_throw_errors # categories: style
+    - overridden_fields # categories: style
+    - package_api_docs # categories: effective dart,public interface
+    - package_names # categories: style
+    - package_prefixed_library_names # categories: style
+    - parameter_assignments # categories: style
+    - prefer_adjacent_string_concatenation # categories: style
+    - prefer_asserts_in_initializer_lists # categories: style
+    - prefer_asserts_with_message # categories: style
+    - prefer_collection_literals # categories: brevity,style
+    - prefer_conditional_assignment # categories: brevity,style
+    - prefer_const_constructors # categories: style
+    - prefer_const_constructors_in_immutables # categories: style
+    - prefer_const_declarations # categories: style
+    - prefer_const_literals_to_create_immutables # categories: style
+    - prefer_constructors_over_static_methods # categories: style
+    - prefer_contains # categories: style
+    - prefer_double_quotes # incompatibles: prefer_single_quotes # categories: style
+    - prefer_expression_function_bodies # categories: brevity,style
+    - prefer_final_fields # categories: effective dart,style
+    - prefer_final_in_for_each # categories: style
+    - prefer_final_locals # incompatibles: unnecessary_final # categories: style
+    - prefer_final_parameters # incompatibles: unnecessary_final,avoid_final_parameters # categories: style
+    - prefer_for_elements_to_map_fromIterable # categories: brevity,style
+    - prefer_foreach # categories: style
+    - prefer_function_declarations_over_variables # categories: effective dart,style
+    - prefer_generic_function_type_aliases # categories: style
+    - prefer_if_elements_to_conditional_expressions # categories: brevity,style
+    - prefer_if_null_operators # categories: brevity,style
+    - prefer_initializing_formals # categories: brevity,style
+    - prefer_inlined_adds # categories: brevity,style
+    - prefer_int_literals # categories: style
+    - prefer_interpolation_to_compose_strings # categories: style
+    - prefer_is_empty # categories: style
+    - prefer_is_not_empty # categories: style
+    - prefer_is_not_operator # categories: brevity,style
+    - prefer_iterable_whereType # categories: style
+    - prefer_mixin # categories: language feature usage,style
+    - prefer_null_aware_method_calls # categories: brevity,style
+    - prefer_null_aware_operators # categories: brevity,style
+    - prefer_relative_imports # incompatibles: always_use_package_imports # categories: error-prone
+    - prefer_single_quotes # incompatibles: prefer_double_quotes # categories: style
+    - prefer_spread_collections # categories: brevity,style
+    - prefer_typing_uninitialized_variables # categories: error-prone,unintentional
+    - prefer_void_to_null # categories: error-prone
+    - provide_deprecation_message # categories: public interface
+    - public_member_api_docs # categories: public interface,style
+    - recursive_getters # categories: error-prone,unintentional
+    - require_trailing_commas # categories: style
+    - secure_pubspec_urls # categories: pub
+    - slash_for_doc_comments # categories: effective dart,style
+    - sort_constructors_first # categories: style
+    - sort_pub_dependencies # categories: pub
+    - sort_unnamed_constructors_first # categories: style
+    - test_types_in_equals # categories: error-prone
+    - throw_in_finally # categories: error-prone
+    - tighten_type_of_initializing_formals # categories: style
+    - type_annotate_public_apis # categories: effective dart,public interface
+    - type_init_formals # categories: effective dart,style
+    - type_literal_in_constant_pattern # categories: style
+    - unawaited_futures # categories: style
+    - unnecessary_await_in_return # categories: style
+    - unnecessary_brace_in_string_interps # categories: brevity,style
+    - unnecessary_breaks # categories: brevity,style
+    - unnecessary_const # categories: brevity,style
+    - unnecessary_constructor_name # categories: brevity,style
+    - unnecessary_final # incompatibles: prefer_final_locals,prefer_final_parameters # categories: effective dart,style
+    - unnecessary_getters_setters # categories: effective dart,style
+    - unnecessary_lambdas # categories: style
+    - unnecessary_late # categories: style
+    - unnecessary_library_directive # categories: brevity
+    - unnecessary_new # categories: brevity,language feature usage,style
+    - unnecessary_null_aware_assignments # categories: brevity,effective dart,style
+    - unnecessary_null_aware_operator_on_extension_on_nullable # categories: style
+    - unnecessary_null_checks # categories: brevity,style
+    - unnecessary_null_in_if_null_operators # categories: style
+    - unnecessary_nullable_for_final_variable_declarations # categories: style
+    - unnecessary_overrides # categories: style
+    - unnecessary_parenthesis # categories: brevity,style
+    - unnecessary_raw_strings # categories: brevity,style
+    - unnecessary_statements # categories: brevity,unintentional
+    - unnecessary_string_escapes # categories: brevity,style
+    - unnecessary_string_interpolations # categories: brevity,style
+    - unnecessary_this # categories: brevity,effective dart,style
+    - unnecessary_to_list_in_spreads # categories: brevity
+    - unreachable_from_main # categories: unused code
+    - unrelated_type_equality_checks # categories: unintentional
+    - unsafe_html # categories: errors
+    - use_enums # categories: style
+    - use_function_type_syntax_for_parameters # categories: style
+    - use_if_null_to_convert_nulls_to_bools # categories: effective dart,style
+    - use_is_even_rather_than_modulo # categories: style
+    - use_late_for_private_fields_and_variables # categories: style
+    - use_named_constants # categories: style
+    - use_raw_strings # categories: style
+    - use_rethrow_when_possible # categories: brevity,effective dart
+    - use_setters_to_change_properties # categories: style
+    - use_string_buffers # categories: non-performant
+    - use_string_in_part_of_directives # categories: effective dart,style
+    - use_super_parameters # categories: brevity
+    - use_test_throws_matchers # categories: style
+    - use_to_and_as_if_applicable # categories: effective dart,style
+    - valid_regexps # categories: unintentional
+    - void_checks # categories: style

--- a/packages/yumemi_lints/lib/dart/3.3/all.yaml
+++ b/packages/yumemi_lints/lib/dart/3.3/all.yaml
@@ -2,213 +2,208 @@
 
 linter:
   rules:
-    # Errors
-    - always_use_package_imports # incompatibles: prefer_relative_imports
-    - avoid_dynamic_calls
-    - avoid_empty_else
-    - avoid_print
-    - avoid_relative_lib_imports
-    - avoid_slow_async_io
-    - avoid_type_to_string
-    - avoid_types_as_parameter_names
-    - cancel_subscriptions
-    - close_sinks
-    - collection_methods_unrelated_type
-    - comment_references
-    - control_flow_in_finally
-    - deprecated_member_use_from_same_package
-    - discarded_futures
-    - empty_statements
-    - hash_and_equals
-    - implicit_reopen
-    - invalid_case_patterns
-    - literal_only_boolean_expressions
-    - no_adjacent_strings_in_list
-    - no_duplicate_case_values
-    - no_self_assignments
-    - no_wildcard_variable_uses
-    - prefer_relative_imports # incompatibles: always_use_package_imports
-    - prefer_void_to_null
-    - test_types_in_equals
-    - throw_in_finally
-    - unnecessary_statements
-    - unrelated_type_equality_checks
-    - unsafe_html
-    - valid_regexps
-
-    # Style
-    - always_declare_return_types
-    - always_put_control_body_on_new_line
-    - always_put_required_named_parameters_first
-    - always_specify_types # incompatibles: avoid_types_on_closure_parameters,omit_local_variable_types
-    - annotate_overrides
-    - annotate_redeclares
-    - avoid_annotating_with_dynamic
-    - avoid_bool_literals_in_conditional_expressions
-    - avoid_catches_without_on_clauses
-    - avoid_catching_errors
-    - avoid_classes_with_only_static_members
-    - avoid_double_and_int_checks
-    - avoid_equals_and_hash_code_on_mutable_classes
-    - avoid_escaping_inner_quotes
-    - avoid_field_initializers_in_const_classes
-    - avoid_final_parameters # incompatibles: prefer_final_parameters
-    - avoid_function_literals_in_foreach_calls
-    - avoid_implementing_value_types
-    - avoid_init_to_null
-    - avoid_js_rounded_ints
-    - avoid_multiple_declarations_per_line
-    - avoid_null_checks_in_equality_operators
-    - avoid_positional_boolean_parameters
-    - avoid_private_typedef_functions
-    - avoid_redundant_argument_values
-    - avoid_renaming_method_parameters
-    - avoid_return_types_on_setters
-    - avoid_returning_null_for_void
-    - avoid_returning_this
-    - avoid_setters_without_getters
-    - avoid_shadowing_type_parameters
-    - avoid_single_cascade_in_expression_statements
-    - avoid_types_on_closure_parameters # incompatibles: always_specify_types
-    - avoid_unused_constructor_parameters
-    - avoid_void_async
-    - await_only_futures
-    - camel_case_extensions
-    - camel_case_types
-    - cascade_invocations
-    - cast_nullable_to_non_nullable
-    - combinators_ordering
-    - conditional_uri_does_not_exist
-    - constant_identifier_names
-    - curly_braces_in_flow_control_structures
-    - dangling_library_doc_comments
-    - deprecated_consistency
-    - directives_ordering
-    - do_not_use_environment
-    - empty_catches
-    - empty_constructor_bodies
-    - eol_at_end_of_file
-    - exhaustive_cases
-    - file_names
-    - flutter_style_todos
-    - implementation_imports
-    - implicit_call_tearoffs
-    - join_return_with_assignment
-    - leading_newlines_in_multiline_strings
-    - library_annotations
-    - library_names
-    - library_prefixes
-    - library_private_types_in_public_api
-    - lines_longer_than_80_chars
-    - matching_super_parameters
-    - missing_whitespace_between_adjacent_strings
-    - no_default_cases
-    - no_leading_underscores_for_library_prefixes
-    - no_leading_underscores_for_local_identifiers
-    - no_literal_bool_comparisons
-    - no_runtimeType_toString
-    - non_constant_identifier_names
-    - noop_primitive_operations
-    - null_check_on_nullable_type_parameter
-    - null_closures
-    - omit_local_variable_types # incompatibles: always_specify_types
-    - one_member_abstracts
-    - only_throw_errors
-    - overridden_fields
-    - package_api_docs
-    - package_prefixed_library_names
-    - parameter_assignments
-    - prefer_adjacent_string_concatenation
-    - prefer_asserts_in_initializer_lists
-    - prefer_asserts_with_message
-    - prefer_collection_literals
-    - prefer_conditional_assignment
-    - prefer_const_constructors
-    - prefer_const_constructors_in_immutables
-    - prefer_const_declarations
-    - prefer_const_literals_to_create_immutables
-    - prefer_constructors_over_static_methods
-    - prefer_contains
-    - prefer_double_quotes # incompatibles: prefer_single_quotes
-    - prefer_expression_function_bodies
-    - prefer_final_fields
-    - prefer_final_in_for_each
-    - prefer_final_locals # incompatibles: unnecessary_final
-    - prefer_final_parameters # incompatibles: unnecessary_final,avoid_final_parameters
-    - prefer_for_elements_to_map_fromIterable
-    - prefer_foreach
-    - prefer_function_declarations_over_variables
-    - prefer_generic_function_type_aliases
-    - prefer_if_elements_to_conditional_expressions
-    - prefer_if_null_operators
-    - prefer_initializing_formals
-    - prefer_inlined_adds
-    - prefer_int_literals
-    - prefer_interpolation_to_compose_strings
-    - prefer_is_empty
-    - prefer_is_not_empty
-    - prefer_is_not_operator
-    - prefer_iterable_whereType
-    - prefer_mixin
-    - prefer_null_aware_method_calls
-    - prefer_null_aware_operators
-    - prefer_single_quotes # incompatibles: prefer_double_quotes
-    - prefer_spread_collections
-    - prefer_typing_uninitialized_variables
-    - provide_deprecation_message
-    - public_member_api_docs
-    - recursive_getters
-    - require_trailing_commas
-    - slash_for_doc_comments
-    - sort_constructors_first
-    - sort_unnamed_constructors_first
-    - tighten_type_of_initializing_formals
-    - type_annotate_public_apis
-    - type_init_formals
-    - type_literal_in_constant_pattern
-    - unawaited_futures
-    - unnecessary_await_in_return
-    - unnecessary_brace_in_string_interps
-    - unnecessary_breaks
-    - unnecessary_const
-    - unnecessary_constructor_name
-    - unnecessary_final # incompatibles: prefer_final_locals,prefer_final_parameters
-    - unnecessary_getters_setters
-    - unnecessary_lambdas
-    - unnecessary_late
-    - unnecessary_library_directive
-    - unnecessary_new
-    - unnecessary_null_aware_assignments
-    - unnecessary_null_aware_operator_on_extension_on_nullable
-    - unnecessary_null_checks
-    - unnecessary_null_in_if_null_operators
-    - unnecessary_nullable_for_final_variable_declarations
-    - unnecessary_overrides
-    - unnecessary_parenthesis
-    - unnecessary_raw_strings
-    - unnecessary_string_escapes
-    - unnecessary_string_interpolations
-    - unnecessary_this
-    - unnecessary_to_list_in_spreads
-    - unreachable_from_main
-    - use_enums
-    - use_function_type_syntax_for_parameters
-    - use_if_null_to_convert_nulls_to_bools
-    - use_is_even_rather_than_modulo
-    - use_late_for_private_fields_and_variables
-    - use_named_constants
-    - use_raw_strings
-    - use_rethrow_when_possible
-    - use_setters_to_change_properties
-    - use_string_buffers
-    - use_string_in_part_of_directives
-    - use_super_parameters
-    - use_test_throws_matchers
-    - use_to_and_as_if_applicable
-    - void_checks
-
-    # Pub
-    - depend_on_referenced_packages
-    - package_names
-    - secure_pubspec_urls
-    - sort_pub_dependencies
+    - always_declare_return_types # categories: style
+    - always_put_control_body_on_new_line # categories: style
+    - always_put_required_named_parameters_first # categories: style
+    - always_specify_types # incompatibles: avoid_types_on_closure_parameters,omit_local_variable_types,omit_obvious_local_variable_types # categories: style
+    - always_use_package_imports # incompatibles: prefer_relative_imports # categories: error-prone
+    - annotate_overrides # categories: style
+    - annotate_redeclares # categories: style
+    - avoid_annotating_with_dynamic # categories: brevity,style
+    - avoid_bool_literals_in_conditional_expressions # categories: brevity
+    - avoid_catches_without_on_clauses # categories: effective dart,style
+    - avoid_catching_errors # categories: style
+    - avoid_classes_with_only_static_members # categories: effective dart,language feature usage,style
+    - avoid_double_and_int_checks # categories: error-prone,web
+    - avoid_dynamic_calls # categories: binary size,error-prone
+    - avoid_empty_else # categories: brevity,error-prone
+    - avoid_equals_and_hash_code_on_mutable_classes # categories: effective dart,style
+    - avoid_escaping_inner_quotes # categories: style
+    - avoid_field_initializers_in_const_classes # categories: style
+    - avoid_final_parameters # incompatibles: prefer_final_parameters # categories: style
+    - avoid_function_literals_in_foreach_calls # categories: style
+    - avoid_implementing_value_types # categories: style
+    - avoid_init_to_null # categories: brevity,effective dart,style
+    - avoid_js_rounded_ints # categories: error-prone,web
+    - avoid_multiple_declarations_per_line # categories: style
+    - avoid_null_checks_in_equality_operators # categories: style
+    - avoid_positional_boolean_parameters # categories: effective dart,style
+    - avoid_print # categories: unintentional
+    - avoid_private_typedef_functions # categories: style
+    - avoid_redundant_argument_values # categories: brevity,style
+    - avoid_relative_lib_imports # categories: error-prone
+    - avoid_renaming_method_parameters # categories: documentation comment maintenance
+    - avoid_return_types_on_setters # categories: brevity,style
+    - avoid_returning_null_for_void # categories: style
+    - avoid_returning_this # categories: effective dart,style
+    - avoid_setters_without_getters # categories: style
+    - avoid_shadowing_type_parameters # categories: error-prone
+    - avoid_single_cascade_in_expression_statements # categories: brevity,style
+    - avoid_slow_async_io # categories: non-performant
+    - avoid_type_to_string # categories: unintentional
+    - avoid_types_as_parameter_names # categories: unintentional
+    - avoid_types_on_closure_parameters # incompatibles: always_specify_types # categories: style
+    - avoid_unused_constructor_parameters # categories: unintentional
+    - avoid_void_async # categories: style
+    - await_only_futures # categories: style
+    - camel_case_extensions # categories: effective dart,style
+    - camel_case_types # categories: effective dart,style
+    - cancel_subscriptions # categories: error-prone,memory leaks
+    - cascade_invocations # categories: brevity,language feature usage,style
+    - cast_nullable_to_non_nullable # categories: error-prone
+    - close_sinks # categories: error-prone,memory leaks
+    - collection_methods_unrelated_type # categories: unintentional
+    - combinators_ordering # categories: style
+    - comment_references # categories: documentation comment maintenance
+    - conditional_uri_does_not_exist # categories: error-prone
+    - constant_identifier_names # categories: style
+    - control_flow_in_finally # categories: error-prone
+    - curly_braces_in_flow_control_structures # categories: error-prone
+    - dangling_library_doc_comments # categories: documentation comment maintenance
+    - depend_on_referenced_packages # categories: pub
+    - deprecated_consistency # categories: style
+    - deprecated_member_use_from_same_package # categories: language feature usage
+    - directives_ordering # categories: style
+    - discarded_futures # categories: error-prone
+    - do_not_use_environment # categories: error-prone
+    - empty_catches # categories: style
+    - empty_constructor_bodies # categories: brevity,effective dart,style
+    - empty_statements # categories: error-prone
+    - eol_at_end_of_file # categories: style
+    - exhaustive_cases # categories: error-prone
+    - file_names # categories: style
+    - flutter_style_todos # categories: style
+    - hash_and_equals # categories: error-prone
+    - implementation_imports # categories: style
+    - implicit_call_tearoffs # categories: style
+    - implicit_reopen # categories: error-prone
+    - invalid_case_patterns # categories: language feature usage
+    - join_return_with_assignment # categories: brevity,style
+    - leading_newlines_in_multiline_strings # categories: style
+    - library_annotations # categories: style
+    - library_names # categories: style
+    - library_prefixes # categories: style
+    - library_private_types_in_public_api # categories: public interface
+    - lines_longer_than_80_chars # categories: style
+    - literal_only_boolean_expressions # categories: unused code
+    - matching_super_parameters # categories: style
+    - missing_whitespace_between_adjacent_strings # categories: error-prone
+    - no_adjacent_strings_in_list # categories: style
+    - no_default_cases # categories: style
+    - no_duplicate_case_values # categories: error-prone
+    - no_leading_underscores_for_library_prefixes # categories: style
+    - no_leading_underscores_for_local_identifiers # categories: style
+    - no_literal_bool_comparisons # categories: effective dart,style
+    - no_runtimeType_toString # categories: non-performant
+    - no_self_assignments # categories: unintentional
+    - no_wildcard_variable_uses # categories: language feature usage,unintentional
+    - non_constant_identifier_names # categories: style
+    - noop_primitive_operations # categories: style
+    - null_check_on_nullable_type_parameter # categories: style
+    - null_closures # categories: error-prone
+    - omit_local_variable_types # incompatibles: always_specify_types # categories: style
+    - one_member_abstracts # categories: effective dart,language feature usage,style
+    - only_throw_errors # categories: style
+    - overridden_fields # categories: style
+    - package_api_docs # categories: effective dart,public interface
+    - package_names # categories: style
+    - package_prefixed_library_names # categories: style
+    - parameter_assignments # categories: style
+    - prefer_adjacent_string_concatenation # categories: style
+    - prefer_asserts_in_initializer_lists # categories: style
+    - prefer_asserts_with_message # categories: style
+    - prefer_collection_literals # categories: brevity,style
+    - prefer_conditional_assignment # categories: brevity,style
+    - prefer_const_constructors # categories: style
+    - prefer_const_constructors_in_immutables # categories: style
+    - prefer_const_declarations # categories: style
+    - prefer_const_literals_to_create_immutables # categories: style
+    - prefer_constructors_over_static_methods # categories: style
+    - prefer_contains # categories: style
+    - prefer_double_quotes # incompatibles: prefer_single_quotes # categories: style
+    - prefer_expression_function_bodies # categories: brevity,style
+    - prefer_final_fields # categories: effective dart,style
+    - prefer_final_in_for_each # categories: style
+    - prefer_final_locals # incompatibles: unnecessary_final # categories: style
+    - prefer_final_parameters # incompatibles: unnecessary_final,avoid_final_parameters # categories: style
+    - prefer_for_elements_to_map_fromIterable # categories: brevity,style
+    - prefer_foreach # categories: style
+    - prefer_function_declarations_over_variables # categories: effective dart,style
+    - prefer_generic_function_type_aliases # categories: style
+    - prefer_if_elements_to_conditional_expressions # categories: brevity,style
+    - prefer_if_null_operators # categories: brevity,style
+    - prefer_initializing_formals # categories: brevity,style
+    - prefer_inlined_adds # categories: brevity,style
+    - prefer_int_literals # categories: style
+    - prefer_interpolation_to_compose_strings # categories: style
+    - prefer_is_empty # categories: style
+    - prefer_is_not_empty # categories: style
+    - prefer_is_not_operator # categories: brevity,style
+    - prefer_iterable_whereType # categories: style
+    - prefer_mixin # categories: language feature usage,style
+    - prefer_null_aware_method_calls # categories: brevity,style
+    - prefer_null_aware_operators # categories: brevity,style
+    - prefer_relative_imports # incompatibles: always_use_package_imports # categories: error-prone
+    - prefer_single_quotes # incompatibles: prefer_double_quotes # categories: style
+    - prefer_spread_collections # categories: brevity,style
+    - prefer_typing_uninitialized_variables # categories: error-prone,unintentional
+    - prefer_void_to_null # categories: error-prone
+    - provide_deprecation_message # categories: public interface
+    - public_member_api_docs # categories: public interface,style
+    - recursive_getters # categories: error-prone,unintentional
+    - require_trailing_commas # categories: style
+    - secure_pubspec_urls # categories: pub
+    - slash_for_doc_comments # categories: effective dart,style
+    - sort_constructors_first # categories: style
+    - sort_pub_dependencies # categories: pub
+    - sort_unnamed_constructors_first # categories: style
+    - test_types_in_equals # categories: error-prone
+    - throw_in_finally # categories: error-prone
+    - tighten_type_of_initializing_formals # categories: style
+    - type_annotate_public_apis # categories: effective dart,public interface
+    - type_init_formals # categories: effective dart,style
+    - type_literal_in_constant_pattern # categories: style
+    - unawaited_futures # categories: style
+    - unnecessary_await_in_return # categories: style
+    - unnecessary_brace_in_string_interps # categories: brevity,style
+    - unnecessary_breaks # categories: brevity,style
+    - unnecessary_const # categories: brevity,style
+    - unnecessary_constructor_name # categories: brevity,style
+    - unnecessary_final # incompatibles: prefer_final_locals,prefer_final_parameters # categories: effective dart,style
+    - unnecessary_getters_setters # categories: effective dart,style
+    - unnecessary_lambdas # categories: style
+    - unnecessary_late # categories: style
+    - unnecessary_library_directive # categories: brevity
+    - unnecessary_new # categories: brevity,language feature usage,style
+    - unnecessary_null_aware_assignments # categories: brevity,effective dart,style
+    - unnecessary_null_aware_operator_on_extension_on_nullable # categories: style
+    - unnecessary_null_checks # categories: brevity,style
+    - unnecessary_null_in_if_null_operators # categories: style
+    - unnecessary_nullable_for_final_variable_declarations # categories: style
+    - unnecessary_overrides # categories: style
+    - unnecessary_parenthesis # categories: brevity,style
+    - unnecessary_raw_strings # categories: brevity,style
+    - unnecessary_statements # categories: brevity,unintentional
+    - unnecessary_string_escapes # categories: brevity,style
+    - unnecessary_string_interpolations # categories: brevity,style
+    - unnecessary_this # categories: brevity,effective dart,style
+    - unnecessary_to_list_in_spreads # categories: brevity
+    - unreachable_from_main # categories: unused code
+    - unrelated_type_equality_checks # categories: unintentional
+    - unsafe_html # categories: errors
+    - use_enums # categories: style
+    - use_function_type_syntax_for_parameters # categories: style
+    - use_if_null_to_convert_nulls_to_bools # categories: effective dart,style
+    - use_is_even_rather_than_modulo # categories: style
+    - use_late_for_private_fields_and_variables # categories: style
+    - use_named_constants # categories: style
+    - use_raw_strings # categories: style
+    - use_rethrow_when_possible # categories: brevity,effective dart
+    - use_setters_to_change_properties # categories: style
+    - use_string_buffers # categories: non-performant
+    - use_string_in_part_of_directives # categories: effective dart,style
+    - use_super_parameters # categories: brevity
+    - use_test_throws_matchers # categories: style
+    - use_to_and_as_if_applicable # categories: effective dart,style
+    - valid_regexps # categories: unintentional
+    - void_checks # categories: style

--- a/packages/yumemi_lints/lib/dart/3.4/all.yaml
+++ b/packages/yumemi_lints/lib/dart/3.4/all.yaml
@@ -2,215 +2,210 @@
 
 linter:
   rules:
-    # Errors
-    - always_use_package_imports # incompatibles: prefer_relative_imports
-    - avoid_dynamic_calls
-    - avoid_empty_else
-    - avoid_print
-    - avoid_relative_lib_imports
-    - avoid_slow_async_io
-    - avoid_type_to_string
-    - avoid_types_as_parameter_names
-    - cancel_subscriptions
-    - close_sinks
-    - collection_methods_unrelated_type
-    - comment_references
-    - control_flow_in_finally
-    - deprecated_member_use_from_same_package
-    - discarded_futures
-    - empty_statements
-    - hash_and_equals
-    - implicit_reopen
-    - invalid_case_patterns
-    - literal_only_boolean_expressions
-    - missing_code_block_language_in_doc_comment
-    - no_adjacent_strings_in_list
-    - no_duplicate_case_values
-    - no_self_assignments
-    - no_wildcard_variable_uses
-    - prefer_relative_imports # incompatibles: always_use_package_imports
-    - prefer_void_to_null
-    - test_types_in_equals
-    - throw_in_finally
-    - unnecessary_statements
-    - unrelated_type_equality_checks
-    - unsafe_html
-    - valid_regexps
-
-    # Style
-    - always_declare_return_types
-    - always_put_control_body_on_new_line
-    - always_put_required_named_parameters_first
-    - always_specify_types # incompatibles: avoid_types_on_closure_parameters,omit_local_variable_types
-    - annotate_overrides
-    - annotate_redeclares
-    - avoid_annotating_with_dynamic
-    - avoid_bool_literals_in_conditional_expressions
-    - avoid_catches_without_on_clauses
-    - avoid_catching_errors
-    - avoid_classes_with_only_static_members
-    - avoid_double_and_int_checks
-    - avoid_equals_and_hash_code_on_mutable_classes
-    - avoid_escaping_inner_quotes
-    - avoid_field_initializers_in_const_classes
-    - avoid_final_parameters # incompatibles: prefer_final_parameters
-    - avoid_function_literals_in_foreach_calls
-    - avoid_implementing_value_types
-    - avoid_init_to_null
-    - avoid_js_rounded_ints
-    - avoid_multiple_declarations_per_line
-    - avoid_null_checks_in_equality_operators
-    - avoid_positional_boolean_parameters
-    - avoid_private_typedef_functions
-    - avoid_redundant_argument_values
-    - avoid_renaming_method_parameters
-    - avoid_return_types_on_setters
-    - avoid_returning_null_for_void
-    - avoid_returning_this
-    - avoid_setters_without_getters
-    - avoid_shadowing_type_parameters
-    - avoid_single_cascade_in_expression_statements
-    - avoid_types_on_closure_parameters # incompatibles: always_specify_types
-    - avoid_unused_constructor_parameters
-    - avoid_void_async
-    - await_only_futures
-    - camel_case_extensions
-    - camel_case_types
-    - cascade_invocations
-    - cast_nullable_to_non_nullable
-    - combinators_ordering
-    - conditional_uri_does_not_exist
-    - constant_identifier_names
-    - curly_braces_in_flow_control_structures
-    - dangling_library_doc_comments
-    - deprecated_consistency
-    - directives_ordering
-    - do_not_use_environment
-    - empty_catches
-    - empty_constructor_bodies
-    - eol_at_end_of_file
-    - exhaustive_cases
-    - file_names
-    - flutter_style_todos
-    - implementation_imports
-    - implicit_call_tearoffs
-    - join_return_with_assignment
-    - leading_newlines_in_multiline_strings
-    - library_annotations
-    - library_names
-    - library_prefixes
-    - library_private_types_in_public_api
-    - lines_longer_than_80_chars
-    - matching_super_parameters
-    - missing_whitespace_between_adjacent_strings
-    - no_default_cases
-    - no_leading_underscores_for_library_prefixes
-    - no_leading_underscores_for_local_identifiers
-    - no_literal_bool_comparisons
-    - no_runtimeType_toString
-    - non_constant_identifier_names
-    - noop_primitive_operations
-    - null_check_on_nullable_type_parameter
-    - null_closures
-    - omit_local_variable_types # incompatibles: always_specify_types
-    - one_member_abstracts
-    - only_throw_errors
-    - overridden_fields
-    - package_api_docs
-    - package_prefixed_library_names
-    - parameter_assignments
-    - prefer_adjacent_string_concatenation
-    - prefer_asserts_in_initializer_lists
-    - prefer_asserts_with_message
-    - prefer_collection_literals
-    - prefer_conditional_assignment
-    - prefer_const_constructors
-    - prefer_const_constructors_in_immutables
-    - prefer_const_declarations
-    - prefer_const_literals_to_create_immutables
-    - prefer_constructors_over_static_methods
-    - prefer_contains
-    - prefer_double_quotes # incompatibles: prefer_single_quotes
-    - prefer_expression_function_bodies
-    - prefer_final_fields
-    - prefer_final_in_for_each
-    - prefer_final_locals # incompatibles: unnecessary_final
-    - prefer_final_parameters # incompatibles: unnecessary_final,avoid_final_parameters
-    - prefer_for_elements_to_map_fromIterable
-    - prefer_foreach
-    - prefer_function_declarations_over_variables
-    - prefer_generic_function_type_aliases
-    - prefer_if_elements_to_conditional_expressions
-    - prefer_if_null_operators
-    - prefer_initializing_formals
-    - prefer_inlined_adds
-    - prefer_int_literals
-    - prefer_interpolation_to_compose_strings
-    - prefer_is_empty
-    - prefer_is_not_empty
-    - prefer_is_not_operator
-    - prefer_iterable_whereType
-    - prefer_mixin
-    - prefer_null_aware_method_calls
-    - prefer_null_aware_operators
-    - prefer_single_quotes # incompatibles: prefer_double_quotes
-    - prefer_spread_collections
-    - prefer_typing_uninitialized_variables
-    - provide_deprecation_message
-    - public_member_api_docs
-    - recursive_getters
-    - require_trailing_commas
-    - slash_for_doc_comments
-    - sort_constructors_first
-    - sort_unnamed_constructors_first
-    - tighten_type_of_initializing_formals
-    - type_annotate_public_apis
-    - type_init_formals
-    - type_literal_in_constant_pattern
-    - unawaited_futures
-    - unnecessary_await_in_return
-    - unnecessary_brace_in_string_interps
-    - unnecessary_breaks
-    - unnecessary_const
-    - unnecessary_constructor_name
-    - unnecessary_final # incompatibles: prefer_final_locals,prefer_final_parameters
-    - unnecessary_getters_setters
-    - unnecessary_lambdas
-    - unnecessary_late
-    - unnecessary_library_directive
-    - unnecessary_library_name
-    - unnecessary_new
-    - unnecessary_null_aware_assignments
-    - unnecessary_null_aware_operator_on_extension_on_nullable
-    - unnecessary_null_checks
-    - unnecessary_null_in_if_null_operators
-    - unnecessary_nullable_for_final_variable_declarations
-    - unnecessary_overrides
-    - unnecessary_parenthesis
-    - unnecessary_raw_strings
-    - unnecessary_string_escapes
-    - unnecessary_string_interpolations
-    - unnecessary_this
-    - unnecessary_to_list_in_spreads
-    - unreachable_from_main
-    - use_enums
-    - use_function_type_syntax_for_parameters
-    - use_if_null_to_convert_nulls_to_bools
-    - use_is_even_rather_than_modulo
-    - use_late_for_private_fields_and_variables
-    - use_named_constants
-    - use_raw_strings
-    - use_rethrow_when_possible
-    - use_setters_to_change_properties
-    - use_string_buffers
-    - use_string_in_part_of_directives
-    - use_super_parameters
-    - use_test_throws_matchers
-    - use_to_and_as_if_applicable
-    - void_checks
-
-    # Pub
-    - depend_on_referenced_packages
-    - package_names
-    - secure_pubspec_urls
-    - sort_pub_dependencies
+    - always_declare_return_types # categories: style
+    - always_put_control_body_on_new_line # categories: style
+    - always_put_required_named_parameters_first # categories: style
+    - always_specify_types # incompatibles: avoid_types_on_closure_parameters,omit_local_variable_types,omit_obvious_local_variable_types # categories: style
+    - always_use_package_imports # incompatibles: prefer_relative_imports # categories: error-prone
+    - annotate_overrides # categories: style
+    - annotate_redeclares # categories: style
+    - avoid_annotating_with_dynamic # categories: brevity,style
+    - avoid_bool_literals_in_conditional_expressions # categories: brevity
+    - avoid_catches_without_on_clauses # categories: effective dart,style
+    - avoid_catching_errors # categories: style
+    - avoid_classes_with_only_static_members # categories: effective dart,language feature usage,style
+    - avoid_double_and_int_checks # categories: error-prone,web
+    - avoid_dynamic_calls # categories: binary size,error-prone
+    - avoid_empty_else # categories: brevity,error-prone
+    - avoid_equals_and_hash_code_on_mutable_classes # categories: effective dart,style
+    - avoid_escaping_inner_quotes # categories: style
+    - avoid_field_initializers_in_const_classes # categories: style
+    - avoid_final_parameters # incompatibles: prefer_final_parameters # categories: style
+    - avoid_function_literals_in_foreach_calls # categories: style
+    - avoid_implementing_value_types # categories: style
+    - avoid_init_to_null # categories: brevity,effective dart,style
+    - avoid_js_rounded_ints # categories: error-prone,web
+    - avoid_multiple_declarations_per_line # categories: style
+    - avoid_null_checks_in_equality_operators # categories: style
+    - avoid_positional_boolean_parameters # categories: effective dart,style
+    - avoid_print # categories: unintentional
+    - avoid_private_typedef_functions # categories: style
+    - avoid_redundant_argument_values # categories: brevity,style
+    - avoid_relative_lib_imports # categories: error-prone
+    - avoid_renaming_method_parameters # categories: documentation comment maintenance
+    - avoid_return_types_on_setters # categories: brevity,style
+    - avoid_returning_null_for_void # categories: style
+    - avoid_returning_this # categories: effective dart,style
+    - avoid_setters_without_getters # categories: style
+    - avoid_shadowing_type_parameters # categories: error-prone
+    - avoid_single_cascade_in_expression_statements # categories: brevity,style
+    - avoid_slow_async_io # categories: non-performant
+    - avoid_type_to_string # categories: unintentional
+    - avoid_types_as_parameter_names # categories: unintentional
+    - avoid_types_on_closure_parameters # incompatibles: always_specify_types # categories: style
+    - avoid_unused_constructor_parameters # categories: unintentional
+    - avoid_void_async # categories: style
+    - await_only_futures # categories: style
+    - camel_case_extensions # categories: effective dart,style
+    - camel_case_types # categories: effective dart,style
+    - cancel_subscriptions # categories: error-prone,memory leaks
+    - cascade_invocations # categories: brevity,language feature usage,style
+    - cast_nullable_to_non_nullable # categories: error-prone
+    - close_sinks # categories: error-prone,memory leaks
+    - collection_methods_unrelated_type # categories: unintentional
+    - combinators_ordering # categories: style
+    - comment_references # categories: documentation comment maintenance
+    - conditional_uri_does_not_exist # categories: error-prone
+    - constant_identifier_names # categories: style
+    - control_flow_in_finally # categories: error-prone
+    - curly_braces_in_flow_control_structures # categories: error-prone
+    - dangling_library_doc_comments # categories: documentation comment maintenance
+    - depend_on_referenced_packages # categories: pub
+    - deprecated_consistency # categories: style
+    - deprecated_member_use_from_same_package # categories: language feature usage
+    - directives_ordering # categories: style
+    - discarded_futures # categories: error-prone
+    - do_not_use_environment # categories: error-prone
+    - empty_catches # categories: style
+    - empty_constructor_bodies # categories: brevity,effective dart,style
+    - empty_statements # categories: error-prone
+    - eol_at_end_of_file # categories: style
+    - exhaustive_cases # categories: error-prone
+    - file_names # categories: style
+    - flutter_style_todos # categories: style
+    - hash_and_equals # categories: error-prone
+    - implementation_imports # categories: style
+    - implicit_call_tearoffs # categories: style
+    - implicit_reopen # categories: error-prone
+    - invalid_case_patterns # categories: language feature usage
+    - join_return_with_assignment # categories: brevity,style
+    - leading_newlines_in_multiline_strings # categories: style
+    - library_annotations # categories: style
+    - library_names # categories: style
+    - library_prefixes # categories: style
+    - library_private_types_in_public_api # categories: public interface
+    - lines_longer_than_80_chars # categories: style
+    - literal_only_boolean_expressions # categories: unused code
+    - matching_super_parameters # categories: style
+    - missing_code_block_language_in_doc_comment # categories: error-prone
+    - missing_whitespace_between_adjacent_strings # categories: error-prone
+    - no_adjacent_strings_in_list # categories: style
+    - no_default_cases # categories: style
+    - no_duplicate_case_values # categories: error-prone
+    - no_leading_underscores_for_library_prefixes # categories: style
+    - no_leading_underscores_for_local_identifiers # categories: style
+    - no_literal_bool_comparisons # categories: effective dart,style
+    - no_runtimeType_toString # categories: non-performant
+    - no_self_assignments # categories: unintentional
+    - no_wildcard_variable_uses # categories: language feature usage,unintentional
+    - non_constant_identifier_names # categories: style
+    - noop_primitive_operations # categories: style
+    - null_check_on_nullable_type_parameter # categories: style
+    - null_closures # categories: error-prone
+    - omit_local_variable_types # incompatibles: always_specify_types # categories: style
+    - one_member_abstracts # categories: effective dart,language feature usage,style
+    - only_throw_errors # categories: style
+    - overridden_fields # categories: style
+    - package_api_docs # categories: effective dart,public interface
+    - package_names # categories: style
+    - package_prefixed_library_names # categories: style
+    - parameter_assignments # categories: style
+    - prefer_adjacent_string_concatenation # categories: style
+    - prefer_asserts_in_initializer_lists # categories: style
+    - prefer_asserts_with_message # categories: style
+    - prefer_collection_literals # categories: brevity,style
+    - prefer_conditional_assignment # categories: brevity,style
+    - prefer_const_constructors # categories: style
+    - prefer_const_constructors_in_immutables # categories: style
+    - prefer_const_declarations # categories: style
+    - prefer_const_literals_to_create_immutables # categories: style
+    - prefer_constructors_over_static_methods # categories: style
+    - prefer_contains # categories: style
+    - prefer_double_quotes # incompatibles: prefer_single_quotes # categories: style
+    - prefer_expression_function_bodies # categories: brevity,style
+    - prefer_final_fields # categories: effective dart,style
+    - prefer_final_in_for_each # categories: style
+    - prefer_final_locals # incompatibles: unnecessary_final # categories: style
+    - prefer_final_parameters # incompatibles: unnecessary_final,avoid_final_parameters # categories: style
+    - prefer_for_elements_to_map_fromIterable # categories: brevity,style
+    - prefer_foreach # categories: style
+    - prefer_function_declarations_over_variables # categories: effective dart,style
+    - prefer_generic_function_type_aliases # categories: style
+    - prefer_if_elements_to_conditional_expressions # categories: brevity,style
+    - prefer_if_null_operators # categories: brevity,style
+    - prefer_initializing_formals # categories: brevity,style
+    - prefer_inlined_adds # categories: brevity,style
+    - prefer_int_literals # categories: style
+    - prefer_interpolation_to_compose_strings # categories: style
+    - prefer_is_empty # categories: style
+    - prefer_is_not_empty # categories: style
+    - prefer_is_not_operator # categories: brevity,style
+    - prefer_iterable_whereType # categories: style
+    - prefer_mixin # categories: language feature usage,style
+    - prefer_null_aware_method_calls # categories: brevity,style
+    - prefer_null_aware_operators # categories: brevity,style
+    - prefer_relative_imports # incompatibles: always_use_package_imports # categories: error-prone
+    - prefer_single_quotes # incompatibles: prefer_double_quotes # categories: style
+    - prefer_spread_collections # categories: brevity,style
+    - prefer_typing_uninitialized_variables # categories: error-prone,unintentional
+    - prefer_void_to_null # categories: error-prone
+    - provide_deprecation_message # categories: public interface
+    - public_member_api_docs # categories: public interface,style
+    - recursive_getters # categories: error-prone,unintentional
+    - require_trailing_commas # categories: style
+    - secure_pubspec_urls # categories: pub
+    - slash_for_doc_comments # categories: effective dart,style
+    - sort_constructors_first # categories: style
+    - sort_pub_dependencies # categories: pub
+    - sort_unnamed_constructors_first # categories: style
+    - test_types_in_equals # categories: error-prone
+    - throw_in_finally # categories: error-prone
+    - tighten_type_of_initializing_formals # categories: style
+    - type_annotate_public_apis # categories: effective dart,public interface
+    - type_init_formals # categories: effective dart,style
+    - type_literal_in_constant_pattern # categories: style
+    - unawaited_futures # categories: style
+    - unnecessary_await_in_return # categories: style
+    - unnecessary_brace_in_string_interps # categories: brevity,style
+    - unnecessary_breaks # categories: brevity,style
+    - unnecessary_const # categories: brevity,style
+    - unnecessary_constructor_name # categories: brevity,style
+    - unnecessary_final # incompatibles: prefer_final_locals,prefer_final_parameters # categories: effective dart,style
+    - unnecessary_getters_setters # categories: effective dart,style
+    - unnecessary_lambdas # categories: style
+    - unnecessary_late # categories: style
+    - unnecessary_library_directive # categories: brevity
+    - unnecessary_library_name # categories: brevity,language feature usage,style
+    - unnecessary_new # categories: brevity,language feature usage,style
+    - unnecessary_null_aware_assignments # categories: brevity,effective dart,style
+    - unnecessary_null_aware_operator_on_extension_on_nullable # categories: style
+    - unnecessary_null_checks # categories: brevity,style
+    - unnecessary_null_in_if_null_operators # categories: style
+    - unnecessary_nullable_for_final_variable_declarations # categories: style
+    - unnecessary_overrides # categories: style
+    - unnecessary_parenthesis # categories: brevity,style
+    - unnecessary_raw_strings # categories: brevity,style
+    - unnecessary_statements # categories: brevity,unintentional
+    - unnecessary_string_escapes # categories: brevity,style
+    - unnecessary_string_interpolations # categories: brevity,style
+    - unnecessary_this # categories: brevity,effective dart,style
+    - unnecessary_to_list_in_spreads # categories: brevity
+    - unreachable_from_main # categories: unused code
+    - unrelated_type_equality_checks # categories: unintentional
+    - unsafe_html # categories: errors
+    - use_enums # categories: style
+    - use_function_type_syntax_for_parameters # categories: style
+    - use_if_null_to_convert_nulls_to_bools # categories: effective dart,style
+    - use_is_even_rather_than_modulo # categories: style
+    - use_late_for_private_fields_and_variables # categories: style
+    - use_named_constants # categories: style
+    - use_raw_strings # categories: style
+    - use_rethrow_when_possible # categories: brevity,effective dart
+    - use_setters_to_change_properties # categories: style
+    - use_string_buffers # categories: non-performant
+    - use_string_in_part_of_directives # categories: effective dart,style
+    - use_super_parameters # categories: brevity
+    - use_test_throws_matchers # categories: style
+    - use_to_and_as_if_applicable # categories: effective dart,style
+    - valid_regexps # categories: unintentional
+    - void_checks # categories: style

--- a/packages/yumemi_lints/lib/dart/3.5/all.yaml
+++ b/packages/yumemi_lints/lib/dart/3.5/all.yaml
@@ -1,0 +1,214 @@
+# GENERATED CODE - DO NOT MODIFY BY HAND
+
+linter:
+  rules:
+    - always_declare_return_types # categories: style
+    - always_put_control_body_on_new_line # categories: style
+    - always_put_required_named_parameters_first # categories: style
+    - always_specify_types # incompatibles: avoid_types_on_closure_parameters,omit_local_variable_types,omit_obvious_local_variable_types # categories: style
+    - always_use_package_imports # incompatibles: prefer_relative_imports # categories: error-prone
+    - annotate_overrides # categories: style
+    - annotate_redeclares # categories: style
+    - avoid_annotating_with_dynamic # categories: brevity,style
+    - avoid_bool_literals_in_conditional_expressions # categories: brevity
+    - avoid_catches_without_on_clauses # categories: effective dart,style
+    - avoid_catching_errors # categories: style
+    - avoid_classes_with_only_static_members # categories: effective dart,language feature usage,style
+    - avoid_double_and_int_checks # categories: error-prone,web
+    - avoid_dynamic_calls # categories: binary size,error-prone
+    - avoid_empty_else # categories: brevity,error-prone
+    - avoid_equals_and_hash_code_on_mutable_classes # categories: effective dart,style
+    - avoid_escaping_inner_quotes # categories: style
+    - avoid_field_initializers_in_const_classes # categories: style
+    - avoid_final_parameters # incompatibles: prefer_final_parameters # categories: style
+    - avoid_function_literals_in_foreach_calls # categories: style
+    - avoid_implementing_value_types # categories: style
+    - avoid_init_to_null # categories: brevity,effective dart,style
+    - avoid_js_rounded_ints # categories: error-prone,web
+    - avoid_multiple_declarations_per_line # categories: style
+    - avoid_null_checks_in_equality_operators # categories: style
+    - avoid_positional_boolean_parameters # categories: effective dart,style
+    - avoid_print # categories: unintentional
+    - avoid_private_typedef_functions # categories: style
+    - avoid_redundant_argument_values # categories: brevity,style
+    - avoid_relative_lib_imports # categories: error-prone
+    - avoid_renaming_method_parameters # categories: documentation comment maintenance
+    - avoid_return_types_on_setters # categories: brevity,style
+    - avoid_returning_null_for_void # categories: style
+    - avoid_returning_this # categories: effective dart,style
+    - avoid_setters_without_getters # categories: style
+    - avoid_shadowing_type_parameters # categories: error-prone
+    - avoid_single_cascade_in_expression_statements # categories: brevity,style
+    - avoid_slow_async_io # categories: non-performant
+    - avoid_type_to_string # categories: unintentional
+    - avoid_types_as_parameter_names # categories: unintentional
+    - avoid_types_on_closure_parameters # incompatibles: always_specify_types # categories: style
+    - avoid_unused_constructor_parameters # categories: unintentional
+    - avoid_void_async # categories: style
+    - await_only_futures # categories: style
+    - camel_case_extensions # categories: effective dart,style
+    - camel_case_types # categories: effective dart,style
+    - cancel_subscriptions # categories: error-prone,memory leaks
+    - cascade_invocations # categories: brevity,language feature usage,style
+    - cast_nullable_to_non_nullable # categories: error-prone
+    - close_sinks # categories: error-prone,memory leaks
+    - collection_methods_unrelated_type # categories: unintentional
+    - combinators_ordering # categories: style
+    - comment_references # categories: documentation comment maintenance
+    - conditional_uri_does_not_exist # categories: error-prone
+    - constant_identifier_names # categories: style
+    - control_flow_in_finally # categories: error-prone
+    - curly_braces_in_flow_control_structures # categories: error-prone
+    - dangling_library_doc_comments # categories: documentation comment maintenance
+    - depend_on_referenced_packages # categories: pub
+    - deprecated_consistency # categories: style
+    - deprecated_member_use_from_same_package # categories: language feature usage
+    - directives_ordering # categories: style
+    - discarded_futures # categories: error-prone
+    - do_not_use_environment # categories: error-prone
+    - document_ignores # categories: style
+    - empty_catches # categories: style
+    - empty_constructor_bodies # categories: brevity,effective dart,style
+    - empty_statements # categories: error-prone
+    - eol_at_end_of_file # categories: style
+    - exhaustive_cases # categories: error-prone
+    - file_names # categories: style
+    - flutter_style_todos # categories: style
+    - hash_and_equals # categories: error-prone
+    - implementation_imports # categories: style
+    - implicit_call_tearoffs # categories: style
+    - implicit_reopen # categories: error-prone
+    - invalid_case_patterns # categories: language feature usage
+    - invalid_runtime_check_with_js_interop_types # categories: error-prone,web
+    - join_return_with_assignment # categories: brevity,style
+    - leading_newlines_in_multiline_strings # categories: style
+    - library_annotations # categories: style
+    - library_names # categories: style
+    - library_prefixes # categories: style
+    - library_private_types_in_public_api # categories: public interface
+    - lines_longer_than_80_chars # categories: style
+    - literal_only_boolean_expressions # categories: unused code
+    - matching_super_parameters # categories: style
+    - missing_code_block_language_in_doc_comment # categories: error-prone
+    - missing_whitespace_between_adjacent_strings # categories: error-prone
+    - no_adjacent_strings_in_list # categories: style
+    - no_default_cases # categories: style
+    - no_duplicate_case_values # categories: error-prone
+    - no_leading_underscores_for_library_prefixes # categories: style
+    - no_leading_underscores_for_local_identifiers # categories: style
+    - no_literal_bool_comparisons # categories: effective dart,style
+    - no_runtimeType_toString # categories: non-performant
+    - no_self_assignments # categories: unintentional
+    - no_wildcard_variable_uses # categories: language feature usage,unintentional
+    - non_constant_identifier_names # categories: style
+    - noop_primitive_operations # categories: style
+    - null_check_on_nullable_type_parameter # categories: style
+    - null_closures # categories: error-prone
+    - omit_local_variable_types # incompatibles: always_specify_types # categories: style
+    - one_member_abstracts # categories: effective dart,language feature usage,style
+    - only_throw_errors # categories: style
+    - overridden_fields # categories: style
+    - package_api_docs # categories: effective dart,public interface
+    - package_names # categories: style
+    - package_prefixed_library_names # categories: style
+    - parameter_assignments # categories: style
+    - prefer_adjacent_string_concatenation # categories: style
+    - prefer_asserts_in_initializer_lists # categories: style
+    - prefer_asserts_with_message # categories: style
+    - prefer_collection_literals # categories: brevity,style
+    - prefer_conditional_assignment # categories: brevity,style
+    - prefer_const_constructors # categories: style
+    - prefer_const_constructors_in_immutables # categories: style
+    - prefer_const_declarations # categories: style
+    - prefer_const_literals_to_create_immutables # categories: style
+    - prefer_constructors_over_static_methods # categories: style
+    - prefer_contains # categories: style
+    - prefer_double_quotes # incompatibles: prefer_single_quotes # categories: style
+    - prefer_expression_function_bodies # categories: brevity,style
+    - prefer_final_fields # categories: effective dart,style
+    - prefer_final_in_for_each # categories: style
+    - prefer_final_locals # incompatibles: unnecessary_final # categories: style
+    - prefer_final_parameters # incompatibles: unnecessary_final,avoid_final_parameters # categories: style
+    - prefer_for_elements_to_map_fromIterable # categories: brevity,style
+    - prefer_foreach # categories: style
+    - prefer_function_declarations_over_variables # categories: effective dart,style
+    - prefer_generic_function_type_aliases # categories: style
+    - prefer_if_elements_to_conditional_expressions # categories: brevity,style
+    - prefer_if_null_operators # categories: brevity,style
+    - prefer_initializing_formals # categories: brevity,style
+    - prefer_inlined_adds # categories: brevity,style
+    - prefer_int_literals # categories: style
+    - prefer_interpolation_to_compose_strings # categories: style
+    - prefer_is_empty # categories: style
+    - prefer_is_not_empty # categories: style
+    - prefer_is_not_operator # categories: brevity,style
+    - prefer_iterable_whereType # categories: style
+    - prefer_mixin # categories: language feature usage,style
+    - prefer_null_aware_method_calls # categories: brevity,style
+    - prefer_null_aware_operators # categories: brevity,style
+    - prefer_relative_imports # incompatibles: always_use_package_imports # categories: error-prone
+    - prefer_single_quotes # incompatibles: prefer_double_quotes # categories: style
+    - prefer_spread_collections # categories: brevity,style
+    - prefer_typing_uninitialized_variables # categories: error-prone,unintentional
+    - prefer_void_to_null # categories: error-prone
+    - provide_deprecation_message # categories: public interface
+    - public_member_api_docs # categories: public interface,style
+    - recursive_getters # categories: error-prone,unintentional
+    - require_trailing_commas # categories: style
+    - secure_pubspec_urls # categories: pub
+    - slash_for_doc_comments # categories: effective dart,style
+    - sort_constructors_first # categories: style
+    - sort_pub_dependencies # categories: pub
+    - sort_unnamed_constructors_first # categories: style
+    - test_types_in_equals # categories: error-prone
+    - throw_in_finally # categories: error-prone
+    - tighten_type_of_initializing_formals # categories: style
+    - type_annotate_public_apis # categories: effective dart,public interface
+    - type_init_formals # categories: effective dart,style
+    - type_literal_in_constant_pattern # categories: style
+    - unawaited_futures # categories: style
+    - unintended_html_in_doc_comment # categories: error-prone
+    - unnecessary_await_in_return # categories: style
+    - unnecessary_brace_in_string_interps # categories: brevity,style
+    - unnecessary_breaks # categories: brevity,style
+    - unnecessary_const # categories: brevity,style
+    - unnecessary_constructor_name # categories: brevity,style
+    - unnecessary_final # incompatibles: prefer_final_locals,prefer_final_parameters # categories: effective dart,style
+    - unnecessary_getters_setters # categories: effective dart,style
+    - unnecessary_lambdas # categories: style
+    - unnecessary_late # categories: style
+    - unnecessary_library_directive # categories: brevity
+    - unnecessary_library_name # categories: brevity,language feature usage,style
+    - unnecessary_new # categories: brevity,language feature usage,style
+    - unnecessary_null_aware_assignments # categories: brevity,effective dart,style
+    - unnecessary_null_aware_operator_on_extension_on_nullable # categories: style
+    - unnecessary_null_checks # categories: brevity,style
+    - unnecessary_null_in_if_null_operators # categories: style
+    - unnecessary_nullable_for_final_variable_declarations # categories: style
+    - unnecessary_overrides # categories: style
+    - unnecessary_parenthesis # categories: brevity,style
+    - unnecessary_raw_strings # categories: brevity,style
+    - unnecessary_statements # categories: brevity,unintentional
+    - unnecessary_string_escapes # categories: brevity,style
+    - unnecessary_string_interpolations # categories: brevity,style
+    - unnecessary_this # categories: brevity,effective dart,style
+    - unnecessary_to_list_in_spreads # categories: brevity
+    - unreachable_from_main # categories: unused code
+    - unrelated_type_equality_checks # categories: unintentional
+    - unsafe_html # categories: errors
+    - use_enums # categories: style
+    - use_function_type_syntax_for_parameters # categories: style
+    - use_if_null_to_convert_nulls_to_bools # categories: effective dart,style
+    - use_is_even_rather_than_modulo # categories: style
+    - use_late_for_private_fields_and_variables # categories: style
+    - use_named_constants # categories: style
+    - use_raw_strings # categories: style
+    - use_rethrow_when_possible # categories: brevity,effective dart
+    - use_setters_to_change_properties # categories: style
+    - use_string_buffers # categories: non-performant
+    - use_string_in_part_of_directives # categories: effective dart,style
+    - use_super_parameters # categories: brevity
+    - use_test_throws_matchers # categories: style
+    - use_to_and_as_if_applicable # categories: effective dart,style
+    - valid_regexps # categories: unintentional
+    - void_checks # categories: style

--- a/packages/yumemi_lints/lib/dart/3.5/recommended.yaml
+++ b/packages/yumemi_lints/lib/dart/3.5/recommended.yaml
@@ -1,0 +1,99 @@
+# GENERATED CODE - DO NOT MODIFY BY HAND
+
+include: package:yumemi_lints/dart/3.5/all.yaml
+
+analyzer:
+  language:
+    # Increase safety as much as possible.
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
+  errors:
+    # By including all.yaml, some rules will conflict. These warnings will be addressed within this file.
+    included_file_warning: ignore
+
+    # Members annotated with `visibleForTesting` should not be referenced outside of the library in which they are declared or libraries within the test directory.
+    invalid_use_of_visible_for_testing_member: error
+
+    # Superclass members should not be unintentionally overridden, as this reduces readability.
+    annotate_overrides: error
+
+    # Class members should not be unintentionally redeclared, as this reduces readability.
+    annotate_redeclares: error
+
+    # When using implements, you do not inherit the method body of `==`, making it nearly impossible to follow the contract of `==`.
+    avoid_implementing_value_types: error
+
+    # Parameter names in overridden methods that do not match the original method's parameter names are usually considered typos.
+    avoid_renaming_method_parameters: error
+
+    # Shadowing type parameters should not be used, as this reduces readability.
+    avoid_shadowing_type_parameters: error
+
+    # Should not reference files that do not exist for conditional imports, as this will result in possible runtime failures.
+    conditional_uri_does_not_exist: error
+
+    # When importing a package, add it as a dependency in pubspec to impose constraints on the dependency, protecting against breaking changes.
+    depend_on_referenced_packages: error
+
+    # Some file systems are not case-sensitive, so many projects require filenames to be all lowercase.
+    file_names: error
+
+    # Files in the package's lib/src directory are not public APIs and should not be imported.
+    implementation_imports: error
+
+    # Some file systems are not case-sensitive, so many projects require filenames to be all lowercase.
+    library_names: error
+
+    # Super parameter names that do not match the parameter name of the corresponding super constructor are usually considered typos.
+    matching_super_parameters: error
+
+    # When unwrapping to a generic type parameter T, using `x!` can lead to a runtime error if T is given a nullable type, so you should use `x as T` instead.
+    null_check_on_nullable_type_parameter: error
+
+    # If package names are not determined according to the rules, unexpected problems may occur.
+    package_names: error
+
+    # Recursive getters are usually considered typos.
+    recursive_getters: error
+
+    # Should not be assigned to `void`.
+    void_checks: error
+
+linter:
+  rules:
+    # Conflicts with enabling `avoid_types_on_closure_parameters`, `omit_local_variable_types`.
+    always_specify_types: false
+
+    # Conflicts with enabling `strict-raw-types`.
+    avoid_annotating_with_dynamic: false
+
+    # There are cases that are warned but not fixed by `dart fix`.
+    cascade_invocations: false
+
+    # Don't use Flutter-style todos.
+    flutter_style_todos: false
+
+    # May add more methods later.
+    one_member_abstracts: false
+
+    # Conflicts with enabling `prefer_single_quotes`.
+    prefer_double_quotes: false
+
+    # Using `=>` has sometimes to reduce readability.
+    prefer_expression_function_bodies: false
+
+    # Conflicts with enabling `avoid_final_parameters`.
+    prefer_final_parameters: false
+
+    # Conflicts with enabling `always_use_package_imports`.
+    prefer_relative_imports: false
+
+    # Don't often develop package.
+    public_member_api_docs: false
+
+    # Conflicts with enabling `prefer_final_locals`.
+    unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/packages/yumemi_lints/lib/flutter/3.0/all.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.0/all.yaml
@@ -4,18 +4,15 @@ include: package:yumemi_lints/dart/2.17/all.yaml
 
 linter:
   rules:
-    # Errors
-    - avoid_web_libraries_in_flutter
-    - diagnostic_describe_all_properties
-    - no_logic_in_create_state
-    - use_build_context_synchronously
-    - use_key_in_widget_constructors
-
-    # Style
-    - avoid_unnecessary_containers
-    - sized_box_for_whitespace
-    - sized_box_shrink_expand
-    - sort_child_properties_last
-    - use_colored_box
-    - use_decorated_box
-    - use_full_hex_values_for_flutter_colors
+    - avoid_unnecessary_containers # categories: flutter,style
+    - avoid_web_libraries_in_flutter # categories: error-prone,flutter,web
+    - diagnostic_describe_all_properties # categories: error-prone,flutter
+    - no_logic_in_create_state # categories: errors,flutter
+    - sized_box_for_whitespace # categories: flutter,style
+    - sized_box_shrink_expand # categories: flutter,style
+    - sort_child_properties_last # categories: flutter,style
+    - use_build_context_synchronously # categories: error-prone,flutter
+    - use_colored_box # categories: flutter,style
+    - use_decorated_box # categories: flutter,style
+    - use_full_hex_values_for_flutter_colors # categories: flutter,style
+    - use_key_in_widget_constructors # categories: flutter,style

--- a/packages/yumemi_lints/lib/flutter/3.10/all.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.10/all.yaml
@@ -4,18 +4,15 @@ include: package:yumemi_lints/dart/3.0/all.yaml
 
 linter:
   rules:
-    # Errors
-    - avoid_web_libraries_in_flutter
-    - diagnostic_describe_all_properties
-    - no_logic_in_create_state
-    - use_build_context_synchronously
-    - use_key_in_widget_constructors
-
-    # Style
-    - avoid_unnecessary_containers
-    - sized_box_for_whitespace
-    - sized_box_shrink_expand
-    - sort_child_properties_last
-    - use_colored_box
-    - use_decorated_box
-    - use_full_hex_values_for_flutter_colors
+    - avoid_unnecessary_containers # categories: flutter,style
+    - avoid_web_libraries_in_flutter # categories: error-prone,flutter,web
+    - diagnostic_describe_all_properties # categories: error-prone,flutter
+    - no_logic_in_create_state # categories: errors,flutter
+    - sized_box_for_whitespace # categories: flutter,style
+    - sized_box_shrink_expand # categories: flutter,style
+    - sort_child_properties_last # categories: flutter,style
+    - use_build_context_synchronously # categories: error-prone,flutter
+    - use_colored_box # categories: flutter,style
+    - use_decorated_box # categories: flutter,style
+    - use_full_hex_values_for_flutter_colors # categories: flutter,style
+    - use_key_in_widget_constructors # categories: flutter,style

--- a/packages/yumemi_lints/lib/flutter/3.13/all.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.13/all.yaml
@@ -4,18 +4,15 @@ include: package:yumemi_lints/dart/3.1/all.yaml
 
 linter:
   rules:
-    # Errors
-    - avoid_web_libraries_in_flutter
-    - diagnostic_describe_all_properties
-    - no_logic_in_create_state
-    - use_build_context_synchronously
-    - use_key_in_widget_constructors
-
-    # Style
-    - avoid_unnecessary_containers
-    - sized_box_for_whitespace
-    - sized_box_shrink_expand
-    - sort_child_properties_last
-    - use_colored_box
-    - use_decorated_box
-    - use_full_hex_values_for_flutter_colors
+    - avoid_unnecessary_containers # categories: flutter,style
+    - avoid_web_libraries_in_flutter # categories: error-prone,flutter,web
+    - diagnostic_describe_all_properties # categories: error-prone,flutter
+    - no_logic_in_create_state # categories: errors,flutter
+    - sized_box_for_whitespace # categories: flutter,style
+    - sized_box_shrink_expand # categories: flutter,style
+    - sort_child_properties_last # categories: flutter,style
+    - use_build_context_synchronously # categories: error-prone,flutter
+    - use_colored_box # categories: flutter,style
+    - use_decorated_box # categories: flutter,style
+    - use_full_hex_values_for_flutter_colors # categories: flutter,style
+    - use_key_in_widget_constructors # categories: flutter,style

--- a/packages/yumemi_lints/lib/flutter/3.16/all.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.16/all.yaml
@@ -4,18 +4,15 @@ include: package:yumemi_lints/dart/3.2/all.yaml
 
 linter:
   rules:
-    # Errors
-    - avoid_web_libraries_in_flutter
-    - diagnostic_describe_all_properties
-    - no_logic_in_create_state
-    - use_build_context_synchronously
-    - use_key_in_widget_constructors
-
-    # Style
-    - avoid_unnecessary_containers
-    - sized_box_for_whitespace
-    - sized_box_shrink_expand
-    - sort_child_properties_last
-    - use_colored_box
-    - use_decorated_box
-    - use_full_hex_values_for_flutter_colors
+    - avoid_unnecessary_containers # categories: flutter,style
+    - avoid_web_libraries_in_flutter # categories: error-prone,flutter,web
+    - diagnostic_describe_all_properties # categories: error-prone,flutter
+    - no_logic_in_create_state # categories: errors,flutter
+    - sized_box_for_whitespace # categories: flutter,style
+    - sized_box_shrink_expand # categories: flutter,style
+    - sort_child_properties_last # categories: flutter,style
+    - use_build_context_synchronously # categories: error-prone,flutter
+    - use_colored_box # categories: flutter,style
+    - use_decorated_box # categories: flutter,style
+    - use_full_hex_values_for_flutter_colors # categories: flutter,style
+    - use_key_in_widget_constructors # categories: flutter,style

--- a/packages/yumemi_lints/lib/flutter/3.19/all.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.19/all.yaml
@@ -4,18 +4,15 @@ include: package:yumemi_lints/dart/3.3/all.yaml
 
 linter:
   rules:
-    # Errors
-    - avoid_web_libraries_in_flutter
-    - diagnostic_describe_all_properties
-    - no_logic_in_create_state
-    - use_build_context_synchronously
-    - use_key_in_widget_constructors
-
-    # Style
-    - avoid_unnecessary_containers
-    - sized_box_for_whitespace
-    - sized_box_shrink_expand
-    - sort_child_properties_last
-    - use_colored_box
-    - use_decorated_box
-    - use_full_hex_values_for_flutter_colors
+    - avoid_unnecessary_containers # categories: flutter,style
+    - avoid_web_libraries_in_flutter # categories: error-prone,flutter,web
+    - diagnostic_describe_all_properties # categories: error-prone,flutter
+    - no_logic_in_create_state # categories: errors,flutter
+    - sized_box_for_whitespace # categories: flutter,style
+    - sized_box_shrink_expand # categories: flutter,style
+    - sort_child_properties_last # categories: flutter,style
+    - use_build_context_synchronously # categories: error-prone,flutter
+    - use_colored_box # categories: flutter,style
+    - use_decorated_box # categories: flutter,style
+    - use_full_hex_values_for_flutter_colors # categories: flutter,style
+    - use_key_in_widget_constructors # categories: flutter,style

--- a/packages/yumemi_lints/lib/flutter/3.22/all.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.22/all.yaml
@@ -4,18 +4,15 @@ include: package:yumemi_lints/dart/3.4/all.yaml
 
 linter:
   rules:
-    # Errors
-    - avoid_web_libraries_in_flutter
-    - diagnostic_describe_all_properties
-    - no_logic_in_create_state
-    - use_build_context_synchronously
-    - use_key_in_widget_constructors
-
-    # Style
-    - avoid_unnecessary_containers
-    - sized_box_for_whitespace
-    - sized_box_shrink_expand
-    - sort_child_properties_last
-    - use_colored_box
-    - use_decorated_box
-    - use_full_hex_values_for_flutter_colors
+    - avoid_unnecessary_containers # categories: flutter,style
+    - avoid_web_libraries_in_flutter # categories: error-prone,flutter,web
+    - diagnostic_describe_all_properties # categories: error-prone,flutter
+    - no_logic_in_create_state # categories: errors,flutter
+    - sized_box_for_whitespace # categories: flutter,style
+    - sized_box_shrink_expand # categories: flutter,style
+    - sort_child_properties_last # categories: flutter,style
+    - use_build_context_synchronously # categories: error-prone,flutter
+    - use_colored_box # categories: flutter,style
+    - use_decorated_box # categories: flutter,style
+    - use_full_hex_values_for_flutter_colors # categories: flutter,style
+    - use_key_in_widget_constructors # categories: flutter,style

--- a/packages/yumemi_lints/lib/flutter/3.24/all.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.24/all.yaml
@@ -1,0 +1,18 @@
+# GENERATED CODE - DO NOT MODIFY BY HAND
+
+include: package:yumemi_lints/dart/3.5/all.yaml
+
+linter:
+  rules:
+    - avoid_unnecessary_containers # categories: flutter,style
+    - avoid_web_libraries_in_flutter # categories: error-prone,flutter,web
+    - diagnostic_describe_all_properties # categories: error-prone,flutter
+    - no_logic_in_create_state # categories: errors,flutter
+    - sized_box_for_whitespace # categories: flutter,style
+    - sized_box_shrink_expand # categories: flutter,style
+    - sort_child_properties_last # categories: flutter,style
+    - use_build_context_synchronously # categories: error-prone,flutter
+    - use_colored_box # categories: flutter,style
+    - use_decorated_box # categories: flutter,style
+    - use_full_hex_values_for_flutter_colors # categories: flutter,style
+    - use_key_in_widget_constructors # categories: flutter,style

--- a/packages/yumemi_lints/lib/flutter/3.24/recommended.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.24/recommended.yaml
@@ -1,0 +1,99 @@
+# GENERATED CODE - DO NOT MODIFY BY HAND
+
+include: package:yumemi_lints/flutter/3.24/all.yaml
+
+analyzer:
+  language:
+    # Increase safety as much as possible.
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
+  errors:
+    # By including all.yaml, some rules will conflict. These warnings will be addressed within this file.
+    included_file_warning: ignore
+
+    # Members annotated with `visibleForTesting` should not be referenced outside of the library in which they are declared or libraries within the test directory.
+    invalid_use_of_visible_for_testing_member: error
+
+    # Superclass members should not be unintentionally overridden, as this reduces readability.
+    annotate_overrides: error
+
+    # Class members should not be unintentionally redeclared, as this reduces readability.
+    annotate_redeclares: error
+
+    # When using implements, you do not inherit the method body of `==`, making it nearly impossible to follow the contract of `==`.
+    avoid_implementing_value_types: error
+
+    # Parameter names in overridden methods that do not match the original method's parameter names are usually considered typos.
+    avoid_renaming_method_parameters: error
+
+    # Shadowing type parameters should not be used, as this reduces readability.
+    avoid_shadowing_type_parameters: error
+
+    # Should not reference files that do not exist for conditional imports, as this will result in possible runtime failures.
+    conditional_uri_does_not_exist: error
+
+    # When importing a package, add it as a dependency in pubspec to impose constraints on the dependency, protecting against breaking changes.
+    depend_on_referenced_packages: error
+
+    # Some file systems are not case-sensitive, so many projects require filenames to be all lowercase.
+    file_names: error
+
+    # Files in the package's lib/src directory are not public APIs and should not be imported.
+    implementation_imports: error
+
+    # Some file systems are not case-sensitive, so many projects require filenames to be all lowercase.
+    library_names: error
+
+    # Super parameter names that do not match the parameter name of the corresponding super constructor are usually considered typos.
+    matching_super_parameters: error
+
+    # When unwrapping to a generic type parameter T, using `x!` can lead to a runtime error if T is given a nullable type, so you should use `x as T` instead.
+    null_check_on_nullable_type_parameter: error
+
+    # If package names are not determined according to the rules, unexpected problems may occur.
+    package_names: error
+
+    # Recursive getters are usually considered typos.
+    recursive_getters: error
+
+    # Should not be assigned to `void`.
+    void_checks: error
+
+linter:
+  rules:
+    # Conflicts with enabling `avoid_types_on_closure_parameters`, `omit_local_variable_types`.
+    always_specify_types: false
+
+    # Conflicts with enabling `strict-raw-types`.
+    avoid_annotating_with_dynamic: false
+
+    # There are cases that are warned but not fixed by `dart fix`.
+    cascade_invocations: false
+
+    # Don't use Flutter-style todos.
+    flutter_style_todos: false
+
+    # May add more methods later.
+    one_member_abstracts: false
+
+    # Conflicts with enabling `prefer_single_quotes`.
+    prefer_double_quotes: false
+
+    # Using `=>` has sometimes to reduce readability.
+    prefer_expression_function_bodies: false
+
+    # Conflicts with enabling `avoid_final_parameters`.
+    prefer_final_parameters: false
+
+    # Conflicts with enabling `always_use_package_imports`.
+    prefer_relative_imports: false
+
+    # Don't often develop package.
+    public_member_api_docs: false
+
+    # Conflicts with enabling `prefer_final_locals`.
+    unnecessary_final: false
+
+    # Don't trigger warnings with methods for simple state updates, among other things.
+    use_setters_to_change_properties: false

--- a/packages/yumemi_lints/lib/flutter/3.3/all.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.3/all.yaml
@@ -4,18 +4,15 @@ include: package:yumemi_lints/dart/2.18/all.yaml
 
 linter:
   rules:
-    # Errors
-    - avoid_web_libraries_in_flutter
-    - diagnostic_describe_all_properties
-    - no_logic_in_create_state
-    - use_build_context_synchronously
-    - use_key_in_widget_constructors
-
-    # Style
-    - avoid_unnecessary_containers
-    - sized_box_for_whitespace
-    - sized_box_shrink_expand
-    - sort_child_properties_last
-    - use_colored_box
-    - use_decorated_box
-    - use_full_hex_values_for_flutter_colors
+    - avoid_unnecessary_containers # categories: flutter,style
+    - avoid_web_libraries_in_flutter # categories: error-prone,flutter,web
+    - diagnostic_describe_all_properties # categories: error-prone,flutter
+    - no_logic_in_create_state # categories: errors,flutter
+    - sized_box_for_whitespace # categories: flutter,style
+    - sized_box_shrink_expand # categories: flutter,style
+    - sort_child_properties_last # categories: flutter,style
+    - use_build_context_synchronously # categories: error-prone,flutter
+    - use_colored_box # categories: flutter,style
+    - use_decorated_box # categories: flutter,style
+    - use_full_hex_values_for_flutter_colors # categories: flutter,style
+    - use_key_in_widget_constructors # categories: flutter,style

--- a/packages/yumemi_lints/lib/flutter/3.7/all.yaml
+++ b/packages/yumemi_lints/lib/flutter/3.7/all.yaml
@@ -4,18 +4,15 @@ include: package:yumemi_lints/dart/2.19/all.yaml
 
 linter:
   rules:
-    # Errors
-    - avoid_web_libraries_in_flutter
-    - diagnostic_describe_all_properties
-    - no_logic_in_create_state
-    - use_build_context_synchronously
-    - use_key_in_widget_constructors
-
-    # Style
-    - avoid_unnecessary_containers
-    - sized_box_for_whitespace
-    - sized_box_shrink_expand
-    - sort_child_properties_last
-    - use_colored_box
-    - use_decorated_box
-    - use_full_hex_values_for_flutter_colors
+    - avoid_unnecessary_containers # categories: flutter,style
+    - avoid_web_libraries_in_flutter # categories: error-prone,flutter,web
+    - diagnostic_describe_all_properties # categories: error-prone,flutter
+    - no_logic_in_create_state # categories: errors,flutter
+    - sized_box_for_whitespace # categories: flutter,style
+    - sized_box_shrink_expand # categories: flutter,style
+    - sort_child_properties_last # categories: flutter,style
+    - use_build_context_synchronously # categories: error-prone,flutter
+    - use_colored_box # categories: flutter,style
+    - use_decorated_box # categories: flutter,style
+    - use_full_hex_values_for_flutter_colors # categories: flutter,style
+    - use_key_in_widget_constructors # categories: flutter,style

--- a/packages/yumemi_lints/pubspec.yaml
+++ b/packages/yumemi_lints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: yumemi_lints
 description: Customizable Linter library which enforces coding standards and best practice for Flutter/Dart apps, packages and plugins.
-version: 2.1.0
+version: 2.2.0
 repository: https://github.com/yumemi-inc/flutter-yumemi-lints
 
 environment:

--- a/tools/update_lint_rules/CHANGELOG.md
+++ b/tools/update_lint_rules/CHANGELOG.md
@@ -1,3 +1,17 @@
-## 1.0.0
+# Changelog
+
+Follow the [Keep a Changelog] format.
+
+## 2.0.0 - 2024-08-15
+
+### Changed
+
+- Remove "group" and change to output "categories".
+
+## 1.0.0 - 2023-09-04
 
 - Initial version.
+
+<!-- Links -->
+
+[Keep a Changelog]: https://keepachangelog.com

--- a/tools/update_lint_rules/lib/src/models/lint_rule.dart
+++ b/tools/update_lint_rules/lib/src/models/lint_rule.dart
@@ -22,7 +22,7 @@ class Rule with _$Rule {
   const factory Rule({
     required String name,
     required String description,
-    required RuleGroup group,
+    required List<String> categories,
     required RuleState state,
     @JsonKey(name: 'incompatible') required List<String> incompatibles,
     required List<RuleSet> sets,
@@ -34,12 +34,6 @@ class Rule with _$Rule {
   factory Rule.fromJson(Map<String, dynamic> json) => _$RuleFromJson(json);
 
   const Rule._();
-}
-
-enum RuleGroup {
-  pub,
-  style,
-  errors,
 }
 
 enum RuleState {

--- a/tools/update_lint_rules/lib/src/models/lint_rule.freezed.dart
+++ b/tools/update_lint_rules/lib/src/models/lint_rule.freezed.dart
@@ -391,7 +391,7 @@ Rule _$RuleFromJson(Map<String, dynamic> json) {
 mixin _$Rule {
   String get name => throw _privateConstructorUsedError;
   String get description => throw _privateConstructorUsedError;
-  RuleGroup get group => throw _privateConstructorUsedError;
+  List<String> get categories => throw _privateConstructorUsedError;
   RuleState get state => throw _privateConstructorUsedError;
   @JsonKey(name: 'incompatible')
   List<String> get incompatibles => throw _privateConstructorUsedError;
@@ -414,7 +414,7 @@ abstract class $RuleCopyWith<$Res> {
   $Res call(
       {String name,
       String description,
-      RuleGroup group,
+      List<String> categories,
       RuleState state,
       @JsonKey(name: 'incompatible') List<String> incompatibles,
       List<RuleSet> sets,
@@ -440,7 +440,7 @@ class _$RuleCopyWithImpl<$Res, $Val extends Rule>
   $Res call({
     Object? name = null,
     Object? description = null,
-    Object? group = null,
+    Object? categories = null,
     Object? state = null,
     Object? incompatibles = null,
     Object? sets = null,
@@ -457,10 +457,10 @@ class _$RuleCopyWithImpl<$Res, $Val extends Rule>
           ? _value.description
           : description // ignore: cast_nullable_to_non_nullable
               as String,
-      group: null == group
-          ? _value.group
-          : group // ignore: cast_nullable_to_non_nullable
-              as RuleGroup,
+      categories: null == categories
+          ? _value.categories
+          : categories // ignore: cast_nullable_to_non_nullable
+              as List<String>,
       state: null == state
           ? _value.state
           : state // ignore: cast_nullable_to_non_nullable
@@ -506,7 +506,7 @@ abstract class _$$_RuleCopyWith<$Res> implements $RuleCopyWith<$Res> {
   $Res call(
       {String name,
       String description,
-      RuleGroup group,
+      List<String> categories,
       RuleState state,
       @JsonKey(name: 'incompatible') List<String> incompatibles,
       List<RuleSet> sets,
@@ -529,7 +529,7 @@ class __$$_RuleCopyWithImpl<$Res> extends _$RuleCopyWithImpl<$Res, _$_Rule>
   $Res call({
     Object? name = null,
     Object? description = null,
-    Object? group = null,
+    Object? categories = null,
     Object? state = null,
     Object? incompatibles = null,
     Object? sets = null,
@@ -546,10 +546,10 @@ class __$$_RuleCopyWithImpl<$Res> extends _$RuleCopyWithImpl<$Res, _$_Rule>
           ? _value.description
           : description // ignore: cast_nullable_to_non_nullable
               as String,
-      group: null == group
-          ? _value.group
-          : group // ignore: cast_nullable_to_non_nullable
-              as RuleGroup,
+      categories: null == categories
+          ? _value._categories
+          : categories // ignore: cast_nullable_to_non_nullable
+              as List<String>,
       state: null == state
           ? _value.state
           : state // ignore: cast_nullable_to_non_nullable
@@ -584,14 +584,15 @@ class _$_Rule extends _Rule {
   const _$_Rule(
       {required this.name,
       required this.description,
-      required this.group,
+      required final List<String> categories,
       required this.state,
       @JsonKey(name: 'incompatible') required final List<String> incompatibles,
       required final List<RuleSet> sets,
       required this.fixStatus,
       required this.details,
       @JsonKey(name: 'sinceDartSdk') required this.since})
-      : _incompatibles = incompatibles,
+      : _categories = categories,
+        _incompatibles = incompatibles,
         _sets = sets,
         super._();
 
@@ -601,8 +602,14 @@ class _$_Rule extends _Rule {
   final String name;
   @override
   final String description;
+  final List<String> _categories;
   @override
-  final RuleGroup group;
+  List<String> get categories {
+    if (_categories is EqualUnmodifiableListView) return _categories;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_categories);
+  }
+
   @override
   final RuleState state;
   final List<String> _incompatibles;
@@ -632,7 +639,7 @@ class _$_Rule extends _Rule {
 
   @override
   String toString() {
-    return 'Rule(name: $name, description: $description, group: $group, state: $state, incompatibles: $incompatibles, sets: $sets, fixStatus: $fixStatus, details: $details, since: $since)';
+    return 'Rule(name: $name, description: $description, categories: $categories, state: $state, incompatibles: $incompatibles, sets: $sets, fixStatus: $fixStatus, details: $details, since: $since)';
   }
 
   @override
@@ -643,7 +650,8 @@ class _$_Rule extends _Rule {
             (identical(other.name, name) || other.name == name) &&
             (identical(other.description, description) ||
                 other.description == description) &&
-            (identical(other.group, group) || other.group == group) &&
+            const DeepCollectionEquality()
+                .equals(other._categories, _categories) &&
             (identical(other.state, state) || other.state == state) &&
             const DeepCollectionEquality()
                 .equals(other._incompatibles, _incompatibles) &&
@@ -660,7 +668,7 @@ class _$_Rule extends _Rule {
       runtimeType,
       name,
       description,
-      group,
+      const DeepCollectionEquality().hash(_categories),
       state,
       const DeepCollectionEquality().hash(_incompatibles),
       const DeepCollectionEquality().hash(_sets),
@@ -686,7 +694,7 @@ abstract class _Rule extends Rule {
   const factory _Rule(
       {required final String name,
       required final String description,
-      required final RuleGroup group,
+      required final List<String> categories,
       required final RuleState state,
       @JsonKey(name: 'incompatible') required final List<String> incompatibles,
       required final List<RuleSet> sets,
@@ -702,7 +710,7 @@ abstract class _Rule extends Rule {
   @override
   String get description;
   @override
-  RuleGroup get group;
+  List<String> get categories;
   @override
   RuleState get state;
   @override

--- a/tools/update_lint_rules/lib/src/models/lint_rule.g.dart
+++ b/tools/update_lint_rules/lib/src/models/lint_rule.g.dart
@@ -15,8 +15,8 @@ _$_Rule _$$_RuleFromJson(Map<String, dynamic> json) => $checkedCreate(
         final val = _$_Rule(
           name: $checkedConvert('name', (v) => v as String),
           description: $checkedConvert('description', (v) => v as String),
-          group: $checkedConvert(
-              'group', (v) => $enumDecode(_$RuleGroupEnumMap, v)),
+          categories: $checkedConvert('categories',
+              (v) => (v as List<dynamic>).map((e) => e as String).toList()),
           state: $checkedConvert(
               'state', (v) => $enumDecode(_$RuleStateEnumMap, v)),
           incompatibles: $checkedConvert('incompatible',
@@ -43,7 +43,7 @@ _$_Rule _$$_RuleFromJson(Map<String, dynamic> json) => $checkedCreate(
 Map<String, dynamic> _$$_RuleToJson(_$_Rule instance) => <String, dynamic>{
       'name': instance.name,
       'description': instance.description,
-      'group': _$RuleGroupEnumMap[instance.group]!,
+      'categories': instance.categories,
       'state': _$RuleStateEnumMap[instance.state]!,
       'incompatible': instance.incompatibles,
       'sets': instance.sets.map((e) => _$RuleSetEnumMap[e]!).toList(),
@@ -51,12 +51,6 @@ Map<String, dynamic> _$$_RuleToJson(_$_Rule instance) => <String, dynamic>{
       'details': instance.details,
       'sinceDartSdk': instance.since.toJson(),
     };
-
-const _$RuleGroupEnumMap = {
-  RuleGroup.pub: 'pub',
-  RuleGroup.style: 'style',
-  RuleGroup.errors: 'errors',
-};
 
 const _$RuleStateEnumMap = {
   RuleState.stable: 'stable',

--- a/tools/update_lint_rules/lib/src/services/analysis_options_service.dart
+++ b/tools/update_lint_rules/lib/src/services/analysis_options_service.dart
@@ -163,35 +163,22 @@ class AnalysisOptionsService {
 linter:
   rules:''');
 
-    String? lintRuleText(Iterable<LintRule> lintRules, RuleGroup group) {
-      final filteredLintRules = lintRules.where((l) => l.rule.group == group);
-      if (filteredLintRules.isEmpty) {
-        return null;
-      }
+    String ruleText(Rule rule) {
       const indent = '    ';
-      final buffer = StringBuffer();
-      buffer.writeln('$indent# ${group.title}');
-      final lintRuleTexts = filteredLintRules.map((l) {
-        final buffer = StringBuffer('$indent- ${l.rule.name}');
-        if (l.rule.incompatibles case final incompatibles
-            when incompatibles.isNotEmpty) {
-          buffer.write(' # incompatibles: ${incompatibles.join(',')}');
-        }
-        return buffer.toString();
-      }).join('\n');
-      buffer.write(lintRuleTexts);
+      final buffer = StringBuffer('$indent- ${rule.name}');
+      if (rule.incompatibles case final incompatibles
+          when incompatibles.isNotEmpty) {
+        buffer.write(' # incompatibles: ${incompatibles.join(',')}');
+      }
+      if (rule.categories case final categories when categories.isNotEmpty) {
+        buffer.write(' # categories: ${categories.join(',')}');
+      }
       return buffer.toString();
     }
 
-    final lintRuleTexts = [
-      lintRuleText(lintRules, RuleGroup.errors),
-      lintRuleText(lintRules, RuleGroup.style),
-      lintRuleText(lintRules, RuleGroup.pub),
-    ].nonNulls;
+    final lintRuleTexts = lintRules.map((l) => ruleText(l.rule));
+    contentBuffer.writeln(lintRuleTexts.join('\n'));
 
-    if (lintRuleTexts.isNotEmpty) {
-      contentBuffer.writeln(lintRuleTexts.join('\n\n'));
-    }
     outputFile.writeAsStringSync(contentBuffer.toString());
   }
 
@@ -246,12 +233,4 @@ linter:
     contentBuffer.writeln(disableLintRuleTexts);
     outputFile.writeAsStringSync(contentBuffer.toString());
   }
-}
-
-extension _RuleGroupTitle on RuleGroup {
-  String get title => switch (this) {
-        RuleGroup.errors => 'Errors',
-        RuleGroup.style => 'Style',
-        RuleGroup.pub => 'Pub',
-      };
 }

--- a/tools/update_lint_rules/pubspec.yaml
+++ b/tools/update_lint_rules/pubspec.yaml
@@ -1,6 +1,6 @@
 name: update_lint_rules
 description: A sample command-line application.
-version: 1.0.0
+version: 2.0.0
 # repository: https://github.com/my_org/my_repo
 
 environment:


### PR DESCRIPTION
## Issue

- close #134 

## Overview (Required)

The following commit removes the `group` field from `machine/rules.json` and adds the `categories` field:

https://github.com/dart-lang/sdk/commit/c50c194d419c09bdbc9267eb8ed045819fb0beed

The above destructive change broke the automatic lint rule generation workflow and has been corrected to work.

Broken workflow:

https://github.com/yumemi-inc/flutter-yumemi-lints/actions/runs/10311663289

Lint rules added in Dart 3.5:

- [document_ignores](https://dart.dev/tools/linter-rules/document_ignores)
- [invalid_runtime_check_with_js_interop_types](https://dart.dev/tools/linter-rules/invalid_runtime_check_with_js_interop_types)
- [unintended_html_in_doc_comment](https://dart.dev/tools/linter-rules/unintended_html_in_doc_comment)

There are no lint rules added in Flutter 3.24.

## Links

- https://dart.dev/tools/linter-rules
