### PR TITLE
Change to be independent of the `path` package

### DIFF
--- a/packages/yumemi_lints/CHANGELOG.md
+++ b/packages/yumemi_lints/CHANGELOG.md
@@ -21,6 +21,12 @@ Examples of version updates are as follows:
 > [!NOTE]
 > Changes to `tools/update_lint_rules` don't affect versioning.
 
+## 2.2.1
+
+### Improvements
+
+- Changed to be independent of the `path` package.
+
 ## 2.2.0
 
 ### Features

--- a/packages/yumemi_lints/lib/src/command_services/update_command_service.dart
+++ b/packages/yumemi_lints/lib/src/command_services/update_command_service.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:meta/meta.dart';
-import 'package:path/path.dart' as path;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
 import 'package:yumemi_lints/src/models/exceptions.dart';
@@ -61,12 +60,8 @@ class UpdateCommandService {
 
   File _getPubspecFile() {
     final pubspecFile = File(
-      path.join(
-        Directory.current.path,
-        'pubspec.yaml',
-      ),
+      '${Directory.current.path}/pubspec.yaml',
     );
-
     if (!pubspecFile.existsSync()) {
       throw Exception(
         'The pubspec.yaml file could not be found in the current directory. '
@@ -232,7 +227,7 @@ class UpdateCommandService {
 
   void _updateAnalysisOptionsFile(String includeLine) {
     final analysisOptionsFile = File(
-      path.join(Directory.current.path, 'analysis_options.yaml'),
+      '${Directory.current.path}/analysis_options.yaml',
     );
     if (!analysisOptionsFile.existsSync()) {
       // Create analysis_options.yaml if it does not exist
@@ -280,6 +275,6 @@ extension _ProjectTypeFormalName on ProjectType {
 
 extension _FileSystemEntityName on FileSystemEntity {
   String get name {
-    return this.path.split('/').last;
+    return path.split('/').last;
   }
 }

--- a/packages/yumemi_lints/lib/src/command_services/update_command_service.dart
+++ b/packages/yumemi_lints/lib/src/command_services/update_command_service.dart
@@ -60,7 +60,10 @@ class UpdateCommandService {
 
   File _getPubspecFile() {
     final pubspecFile = File(
-      '${Directory.current.path}/pubspec.yaml',
+      [
+        Directory.current.path,
+        'pubspec.yaml',
+      ].join(_separator),
     );
     if (!pubspecFile.existsSync()) {
       throw Exception(
@@ -227,7 +230,10 @@ class UpdateCommandService {
 
   void _updateAnalysisOptionsFile(String includeLine) {
     final analysisOptionsFile = File(
-      '${Directory.current.path}/analysis_options.yaml',
+      [
+        Directory.current.path,
+        'analysis_options.yaml',
+      ].join(_separator),
     );
     if (!analysisOptionsFile.existsSync()) {
       // Create analysis_options.yaml if it does not exist
@@ -277,4 +283,21 @@ extension _FileSystemEntityName on FileSystemEntity {
   String get name {
     return path.split('/').last;
   }
+}
+
+bool get _isWindowsStyle {
+  if (Uri.base.scheme != 'file') {
+    return false;
+  }
+  if (!Uri.base.path.endsWith('/')) {
+    return false;
+  }
+  return Uri(path: 'a/b').toFilePath() == r'a\b';
+}
+
+String get _separator {
+  if (_isWindowsStyle) {
+    return r'\';
+  }
+  return '/';
 }

--- a/packages/yumemi_lints/lib/src/command_services/update_command_service.dart
+++ b/packages/yumemi_lints/lib/src/command_services/update_command_service.dart
@@ -160,16 +160,16 @@ class UpdateCommandService {
       );
       throw const CompatibleVersionException();
     }
-    
+
     // If higher than the oldest supported version and lower than the latest
     // supported version, but does not match any of the supported versions,
     // print an error message and exit with an error.
     printMessage(
-        'The version of ${projectType.formalName} $specifiedVersion specified '
-        'in pubspec.yaml does not exist. Please specify the version '
-        'that exists.',
-      );
-      throw const CompatibleVersionException();
+      'The version of ${projectType.formalName} $specifiedVersion specified '
+      'in pubspec.yaml does not exist. Please specify the version '
+      'that exists.',
+    );
+    throw const CompatibleVersionException();
   }
 
   @visibleForTesting

--- a/packages/yumemi_lints/pubspec.yaml
+++ b/packages/yumemi_lints/pubspec.yaml
@@ -10,7 +10,6 @@ dependencies:
   args: ^2.3.1
   file: ^6.1.4
   meta: ^1.7.0
-  path: ^1.8.1
   pub_semver: ^2.1.4
   yaml: ^3.1.1
 


### PR DESCRIPTION
## Issue

- #138 

## Overview (Required)

The `path` package was introduced to utilize the `path.join()` function.  
`path.join()` is a function that concatenates the specified path segments into a single path using the separator of the current platform.  
https://pub.dev/documentation/path/latest/path/join.html

To maintain the previous behavior, I implemented only the necessary parts manually.

## Links

- https://pub.dev/packages/path
- https://pub.dev/documentation/path/latest/path/separator.html
- https://github.com/dart-lang/path/blob/e969f42ed112dd702a9453beb9df6c12ae2d3805/lib/src/style.dart#L36-L45

## Screenshot

https://github.com/user-attachments/assets/66431783-1ec5-492f-ac19-70b66eb47fb1


