### PR TITLE
Change to be independent of the `meta` package

### DIFF
--- a/packages/yumemi_lints/CHANGELOG.md
+++ b/packages/yumemi_lints/CHANGELOG.md
@@ -26,6 +26,7 @@ Examples of version updates are as follows:
 ### Improvements
 
 - Changed to be independent of the `path` package.
+- Changed to be independent of the `meta` package.
 
 ## 2.2.0
 

--- a/packages/yumemi_lints/lib/src/command_services/update_command_service.dart
+++ b/packages/yumemi_lints/lib/src/command_services/update_command_service.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 import 'dart:isolate';
 
-import 'package:meta/meta.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
 import 'package:yumemi_lints/src/models/exceptions.dart';
@@ -120,7 +119,6 @@ class UpdateCommandService {
     return supportedVersions;
   }
 
-  @visibleForTesting
   Version getCompatibleVersion({
     required ProjectType projectType,
     required Version specifiedVersion,
@@ -170,7 +168,6 @@ class UpdateCommandService {
     throw const CompatibleVersionException();
   }
 
-  @visibleForTesting
   Version getFlutterVersion(File pubspecFile) {
     final yaml = loadYaml(pubspecFile.readAsStringSync()) as YamlMap;
     final flutterVersion = (yaml['environment'] as YamlMap)['flutter'];
@@ -185,7 +182,6 @@ class UpdateCommandService {
     return extractVersion(flutterVersion as String);
   }
 
-  @visibleForTesting
   Version getDartVersion(File pubspecFile) {
     final yaml = loadYaml(pubspecFile.readAsStringSync()) as YamlMap;
     final dartVersion = (yaml['environment'] as YamlMap)['sdk'];
@@ -200,7 +196,6 @@ class UpdateCommandService {
     return extractVersion(dartVersion as String);
   }
 
-  @visibleForTesting
   Version extractVersion(String versionString) {
     if (versionString.contains('<') && !versionString.contains('>=')) {
       throw const FormatException('Please specify the minimum version.');

--- a/packages/yumemi_lints/pubspec.yaml
+++ b/packages/yumemi_lints/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 dependencies:
   args: ^2.3.1
   file: ^6.1.4
-  meta: ^1.7.0
   pub_semver: ^2.1.4
   yaml: ^3.1.1
 


### PR DESCRIPTION
## Issue

- #138 

## Overview (Required)

The `meta` package was introduced to use `@visibleForTesting`. I have removed it, judging that it will no longer be necessary if the processing part in question is extracted to Model or Service. This extraction work is planned to be handled in a separate pull request.

## Links

- https://pub.dev/packages/meta
- https://pub.dev/documentation/meta/latest/meta/visibleForTesting-constant.html
