### PR TITLE
Change to be independent of the `pub_semver` package

### DIFF
--- a/packages/yumemi_lints/CHANGELOG.md
+++ b/packages/yumemi_lints/CHANGELOG.md
@@ -27,6 +27,7 @@ Examples of version updates are as follows:
 
 - Changed to be independent of the `path` package.
 - Changed to be independent of the `meta` package.
+- Changed to be independent of the `pub_semver` package.
 
 ## 2.2.0
 

--- a/packages/yumemi_lints/analysis_options.yaml
+++ b/packages/yumemi_lints/analysis_options.yaml
@@ -3,3 +3,6 @@ include: package:yumemi_lints/dart/2.17/recommended.yaml
 linter:
   rules:
     avoid_print: false
+
+    # This project does not use the `meta` package, so it has been disabled.
+    avoid_equals_and_hash_code_on_mutable_classes: false

--- a/packages/yumemi_lints/lib/src/models/version.dart
+++ b/packages/yumemi_lints/lib/src/models/version.dart
@@ -1,0 +1,81 @@
+/// A parsed semantic version number. However, only the major and minor
+/// versions are processed.
+class Version implements Comparable<Version> {
+  const Version(this._major, this._minor)
+      : assert(_major >= 0, 'Major version must be non-negative.'),
+        assert(_minor >= 0, 'Minor version must be non-negative.');
+
+  factory Version.parse(String text) {
+    if (text.contains('<') && !text.contains('>=')) {
+      throw MinimumVersionMissingException(text);
+    }
+
+    RegExp regExp;
+    if (text.contains('>=')) {
+      regExp = RegExp(r'>=\s*(\d+)\.(\d+)');
+    } else {
+      regExp = RegExp(r'\^?(\d+)\.(\d+)');
+    }
+    final match = regExp.firstMatch(text);
+
+    if (match == null) {
+      throw UnsupportedVersionFormatException(text);
+    }
+
+    final major = int.parse(match[1]!);
+    final minor = int.parse(match[2]!);
+    return Version(major, minor);
+  }
+
+  final int _major;
+  final int _minor;
+
+  @override
+  bool operator ==(Object other) =>
+      other is Version && _major == other._major && _minor == other._minor;
+
+  @override
+  int get hashCode => _major ^ _minor;
+
+  @override
+  int compareTo(Version other) {
+    if (_major != other._major) {
+      return _major.compareTo(other._major);
+    }
+    if (_minor != other._minor) {
+      return _minor.compareTo(other._minor);
+    }
+    return 0;
+  }
+
+  @override
+  String toString() => '$_major.$_minor';
+}
+
+abstract class _VersionParseException extends FormatException {
+  const _VersionParseException({
+    required String text,
+    required String message,
+  }) : super(
+          'Could not parse `$text`. $message',
+        );
+}
+
+class MinimumVersionMissingException extends _VersionParseException {
+  const MinimumVersionMissingException(String text)
+      : super(
+          text: text,
+          message: 'The minimum version must be specified if the version '
+              'is in range format.',
+        );
+}
+
+class UnsupportedVersionFormatException extends _VersionParseException {
+  const UnsupportedVersionFormatException(String text)
+      : super(
+          text: text,
+          message:
+              'Only version formats matching the following regular expressions '
+              r'are supported: `>=\s*(\d+)\.(\d+)` or `\^?(\d+)\.(\d+)`.',
+        );
+}

--- a/packages/yumemi_lints/lib/src/models/version.dart
+++ b/packages/yumemi_lints/lib/src/models/version.dart
@@ -48,6 +48,11 @@ class Version implements Comparable<Version> {
     return 0;
   }
 
+  bool operator <(Version other) => compareTo(other) < 0;
+  bool operator >(Version other) => compareTo(other) > 0;
+  bool operator <=(Version other) => compareTo(other) <= 0;
+  bool operator >=(Version other) => compareTo(other) >= 0;
+
   @override
   String toString() => '$_major.$_minor';
 }

--- a/packages/yumemi_lints/lib/src/models/version.dart
+++ b/packages/yumemi_lints/lib/src/models/version.dart
@@ -10,7 +10,7 @@ class Version implements Comparable<Version> {
       throw MinimumVersionMissingException(text);
     }
 
-    RegExp regExp;
+    final RegExp regExp;
     if (text.contains('>=')) {
       regExp = RegExp(r'>=\s*(\d+)\.(\d+)');
     } else {

--- a/packages/yumemi_lints/pubspec.yaml
+++ b/packages/yumemi_lints/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 dependencies:
   args: ^2.3.1
   file: ^6.1.4
-  pub_semver: ^2.1.4
   yaml: ^3.1.1
 
 dev_dependencies:

--- a/packages/yumemi_lints/test/command_services/update_command_service_test.dart
+++ b/packages/yumemi_lints/test/command_services/update_command_service_test.dart
@@ -1,10 +1,10 @@
 import 'package:file/memory.dart';
 import 'package:mockito/mockito.dart';
-import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 import 'package:yumemi_lints/src/command_services/update_command_service.dart';
 import 'package:yumemi_lints/src/models/exceptions.dart';
 import 'package:yumemi_lints/src/models/project_type.dart';
+import 'package:yumemi_lints/src/models/version.dart';
 
 void main() {
   const updateCommandService = UpdateCommandService();
@@ -62,65 +62,6 @@ environment:
         ),
       );
     });
-  });
-
-  group('UpdateCommandService.extractVersion', () {
-    // arrange
-    const versions = [
-      '^2.17.0',
-      '2.17.0',
-      '>=2.17.0 <4.0.0',
-      '<4.0.0 >=2.17.0',
-      '^2.17.1',
-    ];
-
-    for (var i = 0; i < versions.length; i++) {
-      // act
-      final version = updateCommandService.extractVersion(versions[i]);
-
-      test(
-          'Successfully extract version '
-          'when input version is ${versions[i]}', () {
-        // assert
-        expect(
-          version,
-          Version(2, 17, 0),
-        );
-      });
-    }
-
-    // arrange
-    const versionErrorScenarios = [
-      {
-        'version': 'any',
-        'errorMessage': 'The version of Dart or Flutter could not be found '
-            'in pubspec.yaml. Please ensure that '
-            'the version is correctly specified for Dart or Flutter.',
-      },
-      {
-        'version': '<4.0.0',
-        'errorMessage': 'Please specify the minimum version.',
-      },
-    ];
-
-    for (var i = 0; i < versionErrorScenarios.length; i++) {
-      test(
-          'Failure to extract version '
-          'when input version is ${versionErrorScenarios[i]['version']}', () {
-        // act, assert
-        expect(
-          () => updateCommandService
-              .extractVersion(versionErrorScenarios[i]['version']!),
-          throwsA(
-            isA<FormatException>().having(
-              (e) => e.message,
-              'errorMessage',
-              versionErrorScenarios[i]['errorMessage'],
-            ),
-          ),
-        );
-      });
-    }
   });
 
   group('UpdateCommandService.getCompatibleVersion', () {

--- a/packages/yumemi_lints/test/models/version_test.dart
+++ b/packages/yumemi_lints/test/models/version_test.dart
@@ -1,0 +1,78 @@
+import 'package:test/test.dart';
+import 'package:yumemi_lints/src/models/version.dart';
+
+void main() {
+  group('Version.parse()', () {
+    // arrange
+    const successfulScenarios = [
+      {
+        'input': '^2.17.0',
+        'expected': Version(2, 17),
+      },
+      {
+        'input': '2.17.0',
+        'expected': Version(2, 17),
+      },
+      {
+        'input': '>=2.17.0 <4.0.0',
+        'expected': Version(2, 17),
+      },
+      {
+        'input': '<4.0.0 >=2.17.0',
+        'expected': Version(2, 17),
+      },
+      {
+        'input': '^2.17.1',
+        'expected': Version(2, 17),
+      },
+    ];
+
+    for (final scenario in successfulScenarios) {
+      final input = scenario['input']! as String;
+      final expected = scenario['expected']! as Version;
+
+      test(
+        'The version is successfully parsed '
+        'when the input text is `$input`',
+        () {
+          // act
+          final actual = Version.parse(input);
+
+          // assert
+          expect(actual, expected);
+        },
+      );
+    }
+
+    // arrange
+    final failureScenarios = [
+      {
+        'input': '<4.0.0',
+        'expected': throwsA(isA<MinimumVersionMissingException>()),
+      },
+      {
+        'input': 'any',
+        'expected': throwsA(isA<UnsupportedVersionFormatException>()),
+      },
+    ];
+
+    for (final scenario in failureScenarios) {
+      final input = scenario['input']! as String;
+      final expected = scenario['expected']! as Matcher;
+
+      test(
+        'The version fails to be parsed '
+        'when the input text is `$input`',
+        () {
+          // act
+          void actual() {
+            Version.parse(input);
+          }
+
+          // assert
+          expect(actual, expected);
+        },
+      );
+    }
+  });
+}


### PR DESCRIPTION
## Issue

- #138 

## Overview (Required)

The `pub_semver` package was introduced to parse Dart and Flutter versions and to handle and compare only the Major and Minor versions for display. I implemented that part independently and removed the `pub_semver` package.

## Links

- https://pub.dev/packages/pub_semver

## Screenshot

https://github.com/user-attachments/assets/9b80bc18-450f-44ee-be87-ff093a0f6978

