### PR TITLE
Change to be independent of the `yaml` and `file` package

### DIFF
--- a/packages/yumemi_lints/CHANGELOG.md
+++ b/packages/yumemi_lints/CHANGELOG.md
@@ -29,6 +29,7 @@ Examples of version updates are as follows:
 - Changed to be independent of the `meta` package.
 - Changed to be independent of the `pub_semver` package.
 - Changed to be independent of the `yaml` package.
+- Changed to be independent of the `file` package.
 
 ## 2.2.0
 

--- a/packages/yumemi_lints/CHANGELOG.md
+++ b/packages/yumemi_lints/CHANGELOG.md
@@ -28,6 +28,7 @@ Examples of version updates are as follows:
 - Changed to be independent of the `path` package.
 - Changed to be independent of the `meta` package.
 - Changed to be independent of the `pub_semver` package.
+- Changed to be independent of the `yaml` package.
 
 ## 2.2.0
 

--- a/packages/yumemi_lints/example/pubspec.lock
+++ b/packages/yumemi_lints/example/pubspec.lock
@@ -8,69 +8,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.3.1"
-  collection:
-    dependency: transitive
-    description:
-      name: collection
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.17.0"
-  file:
-    dependency: transitive
-    description:
-      name: file
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "6.1.4"
-  meta:
-    dependency: transitive
-    description:
-      name: meta
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.15.0"
-  path:
-    dependency: transitive
-    description:
-      name: path
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.8.3"
-  pub_semver:
-    dependency: transitive
-    description:
-      name: pub_semver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.4"
-  source_span:
-    dependency: transitive
-    description:
-      name: source_span
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.9.1"
-  string_scanner:
-    dependency: transitive
-    description:
-      name: string_scanner
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.1"
-  term_glyph:
-    dependency: transitive
-    description:
-      name: term_glyph
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.1"
-  yaml:
-    dependency: transitive
-    description:
-      name: yaml
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.1.1"
   yumemi_lints:
     dependency: "direct dev"
     description:

--- a/packages/yumemi_lints/lib/src/command_services/update_command_service.dart
+++ b/packages/yumemi_lints/lib/src/command_services/update_command_service.dart
@@ -186,7 +186,7 @@ class UpdateCommandService {
   Version getDartVersion(File pubspecFile) {
     final yaml = Yaml.parse(pubspecFile);
     final environment = yaml.yamlMap['environment'] as Map<String, dynamic>;
-    final dartVersion = environment['flutter'] as String?;
+    final dartVersion = environment['sdk'] as String?;
 
     if (dartVersion == null) {
       throw const FormatException(

--- a/packages/yumemi_lints/lib/src/command_services/update_command_service.dart
+++ b/packages/yumemi_lints/lib/src/command_services/update_command_service.dart
@@ -24,12 +24,13 @@ class UpdateCommandService {
   Future<ExitStatus> _updateLintRule(ProjectType projectType) async {
     final Version specifiedVersion;
     try {
+      final file = _getPubspecFile().readAsStringSync();
       switch (projectType) {
         case ProjectType.dart:
-          specifiedVersion = getDartVersion(_getPubspecFile());
+          specifiedVersion = getDartVersion(file);
           break;
         case ProjectType.flutter:
-          specifiedVersion = getFlutterVersion(_getPubspecFile());
+          specifiedVersion = getFlutterVersion(file);
           break;
       }
     } on FormatException catch (e) {
@@ -168,8 +169,8 @@ class UpdateCommandService {
     throw const CompatibleVersionException();
   }
 
-  Version getFlutterVersion(File pubspecFile) {
-    final yaml = Yaml.parse(pubspecFile);
+  Version getFlutterVersion(String pubspecFileString) {
+    final yaml = Yaml.parse(pubspecFileString);
     final environment = yaml.yamlMap['environment'] as Map<String, dynamic>;
     final flutterVersion = environment['flutter'] as String?;
 
@@ -183,8 +184,8 @@ class UpdateCommandService {
     return Version.parse(flutterVersion);
   }
 
-  Version getDartVersion(File pubspecFile) {
-    final yaml = Yaml.parse(pubspecFile);
+  Version getDartVersion(String pubspecFileString) {
+    final yaml = Yaml.parse(pubspecFileString);
     final environment = yaml.yamlMap['environment'] as Map<String, dynamic>;
     final dartVersion = environment['sdk'] as String?;
 

--- a/packages/yumemi_lints/lib/src/command_services/update_command_service.dart
+++ b/packages/yumemi_lints/lib/src/command_services/update_command_service.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 import 'dart:isolate';
 
-import 'package:yaml/yaml.dart';
 import 'package:yumemi_lints/src/models/exceptions.dart';
 import 'package:yumemi_lints/src/models/exit_status.dart';
 import 'package:yumemi_lints/src/models/project_type.dart';
@@ -169,8 +168,9 @@ class UpdateCommandService {
   }
 
   Version getFlutterVersion(File pubspecFile) {
-    final yaml = loadYaml(pubspecFile.readAsStringSync()) as YamlMap;
-    final flutterVersion = (yaml['environment'] as YamlMap)['flutter'];
+    final yamls = parseYamlToMap(pubspecFile.readAsStringSync());
+    final environment = yamls['environment'] as Map<String, dynamic>;
+    final flutterVersion = environment['flutter'] as String?;
 
     if (flutterVersion == null) {
       throw const FormatException(
@@ -179,12 +179,66 @@ class UpdateCommandService {
       );
     }
 
-    return Version.parse(flutterVersion as String);
+    return Version.parse(flutterVersion);
+  }
+
+  Map<String, dynamic> parseYamlToMap(String yaml) {
+    final lines = yaml.split('\n');
+    final result = <String, dynamic>{};
+    final stack = <String>[];
+    var current = result;
+
+    for (final line in lines) {
+      final trimmed = line.trim();
+      if (trimmed.isEmpty || trimmed.startsWith('#')) {
+        continue;
+      }
+
+      // Get parent element if there is an indent.
+      final indent = line.length - line.trimLeft().length;
+      while (stack.length > indent) {
+        stack.removeLast();
+        current = stack.isEmpty
+            ? result
+            : current['__parent__'] as Map<String, dynamic>;
+      }
+
+      if (trimmed.contains(':')) {
+        final parts = trimmed.split(':');
+        final key = parts[0].trim();
+        final value = parts.sublist(1).join(':').trim();
+        final newMap = <String, dynamic>{};
+        // If value is empty,
+        // create a new Map assuming a child element and add it to current.
+        if (value.isEmpty) {
+          current[key] = newMap;
+          newMap['__parent__'] = current;
+          stack.add(key);
+          current = newMap;
+        } else {
+          current[key] = value;
+        }
+      }
+    }
+
+    _cleanParent(result);
+    return result;
+  }
+
+  // Delete the "__parent__" key.
+  void _cleanParent(Map<String, dynamic> map) {
+    map.remove('__parent__');
+    for (final value in map.values) {
+      if (value is Map<String, dynamic>) {
+        _cleanParent(value);
+      }
+    }
   }
 
   Version getDartVersion(File pubspecFile) {
-    final yaml = loadYaml(pubspecFile.readAsStringSync()) as YamlMap;
-    final dartVersion = (yaml['environment'] as YamlMap)['sdk'];
+    final yamls = parseYamlToMap(pubspecFile.readAsStringSync());
+    final environment = yamls['environment'] as Map<String, dynamic>;
+    final dartVersion = environment['flutter'] as String?;
 
     if (dartVersion == null) {
       throw const FormatException(
@@ -193,7 +247,7 @@ class UpdateCommandService {
       );
     }
 
-    return Version.parse(dartVersion as String);
+    return Version.parse(dartVersion);
   }
 
   void _updateAnalysisOptionsFile(String includeLine) {

--- a/packages/yumemi_lints/lib/src/command_services/update_command_service.dart
+++ b/packages/yumemi_lints/lib/src/command_services/update_command_service.dart
@@ -24,13 +24,13 @@ class UpdateCommandService {
   Future<ExitStatus> _updateLintRule(ProjectType projectType) async {
     final Version specifiedVersion;
     try {
-      final file = _getPubspecFile().readAsStringSync();
+      final fileContent = _getPubspecFile().readAsStringSync();
       switch (projectType) {
         case ProjectType.dart:
-          specifiedVersion = getDartVersion(file);
+          specifiedVersion = getDartVersion(fileContent);
           break;
         case ProjectType.flutter:
-          specifiedVersion = getFlutterVersion(file);
+          specifiedVersion = getFlutterVersion(fileContent);
           break;
       }
     } on FormatException catch (e) {
@@ -169,8 +169,8 @@ class UpdateCommandService {
     throw const CompatibleVersionException();
   }
 
-  Version getFlutterVersion(String pubspecFileString) {
-    final yaml = Yaml.parse(pubspecFileString);
+  Version getFlutterVersion(String pubspecFileContent) {
+    final yaml = Yaml.parse(pubspecFileContent);
     final environment = yaml.yamlMap['environment'] as Map<String, dynamic>;
     final flutterVersion = environment['flutter'] as String?;
 
@@ -184,8 +184,8 @@ class UpdateCommandService {
     return Version.parse(flutterVersion);
   }
 
-  Version getDartVersion(String pubspecFileString) {
-    final yaml = Yaml.parse(pubspecFileString);
+  Version getDartVersion(String pubspecFileContent) {
+    final yaml = Yaml.parse(pubspecFileContent);
     final environment = yaml.yamlMap['environment'] as Map<String, dynamic>;
     final dartVersion = environment['sdk'] as String?;
 

--- a/packages/yumemi_lints/lib/src/models/yaml.dart
+++ b/packages/yumemi_lints/lib/src/models/yaml.dart
@@ -5,8 +5,8 @@ class Yaml {
 
   // Convert and parse the file system into a Yaml file,
   // obtain a YamlMap, and then create a Yaml object.
-  factory Yaml.parse(File file) {
-    final lines = file.readAsStringSync().split('\n');
+  factory Yaml.parse(String file) {
+    final lines = file.split('\n');
     final result = <String, dynamic>{};
     final stack = <String>[];
     var current = result;

--- a/packages/yumemi_lints/lib/src/models/yaml.dart
+++ b/packages/yumemi_lints/lib/src/models/yaml.dart
@@ -1,0 +1,63 @@
+import 'dart:io';
+
+class Yaml {
+  const Yaml._(this.yamlMap);
+
+  // Convert and parse the file system into a Yaml file,
+  // obtain a YamlMap, and then create a Yaml object.
+  factory Yaml.parse(File file) {
+    final lines = file.readAsStringSync().split('\n');
+    final result = <String, dynamic>{};
+    final stack = <String>[];
+    var current = result;
+
+    for (final line in lines) {
+      final trimmed = line.trim();
+      if (trimmed.isEmpty || trimmed.startsWith('#')) {
+        continue;
+      }
+
+      // Get parent element if there is an indent.
+      final indent = line.length - line.trimLeft().length;
+      while (stack.length > indent) {
+        stack.removeLast();
+        current = stack.isEmpty
+            ? result
+            : current['__parent__'] as Map<String, dynamic>;
+      }
+
+      if (trimmed.contains(':')) {
+        final parts = trimmed.split(':');
+        final key = parts[0].trim();
+        final value = parts.sublist(1).join(':').trim();
+        final newMap = <String, dynamic>{};
+        // If value is empty,
+        // create a new Map assuming a child element and add it to current.
+        if (value.isEmpty) {
+          current[key] = newMap;
+          newMap['__parent__'] = current;
+          stack.add(key);
+          current = newMap;
+        } else {
+          current[key] = value;
+        }
+      }
+    }
+    // Delete the "__parent__" key.
+    void cleanParent(Map<String, dynamic> map) {
+      map.remove('__parent__');
+      for (final value in map.values) {
+        if (value is Map<String, dynamic>) {
+          cleanParent(value);
+        }
+      }
+    }
+
+    cleanParent(result);
+    return Yaml._(result);
+  }
+
+  final YamlMap yamlMap;
+}
+
+typedef YamlMap = Map<String, dynamic>;

--- a/packages/yumemi_lints/lib/src/models/yaml.dart
+++ b/packages/yumemi_lints/lib/src/models/yaml.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 class Yaml {
   const Yaml._(this.yamlMap);
 

--- a/packages/yumemi_lints/pubspec.yaml
+++ b/packages/yumemi_lints/pubspec.yaml
@@ -8,7 +8,6 @@ environment:
 
 dependencies:
   args: ^2.3.1
-  file: ^6.1.4
 
 dev_dependencies:
   mockito: ^5.3.2

--- a/packages/yumemi_lints/pubspec.yaml
+++ b/packages/yumemi_lints/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 dependencies:
   args: ^2.3.1
   file: ^6.1.4
-  yaml: ^3.1.1
 
 dev_dependencies:
   mockito: ^5.3.2

--- a/packages/yumemi_lints/test/command_services/update_command_service_test.dart
+++ b/packages/yumemi_lints/test/command_services/update_command_service_test.dart
@@ -1,4 +1,3 @@
-import 'package:file/memory.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 import 'package:yumemi_lints/src/command_services/update_command_service.dart';
@@ -13,13 +12,10 @@ void main() {
         'Throws FormatException '
         'when the flutter version is not listed in pubspec.yaml', () {
       // arrange
-      final file = MemoryFileSystem().file('file')
-        ..writeAsStringSync(
-          '''
+      const file = '''
 environment:
   sdk: '2.17.0'
-''',
-        );
+''';
 
       // act, assert
       expect(
@@ -41,13 +37,10 @@ environment:
         'Throws FormatException '
         'when the dart version is not listed in pubspec.yaml', () {
       // arrange
-      final file = MemoryFileSystem().file('file')
-        ..writeAsStringSync(
-          '''
+      const file = '''
 environment:
   flutter: '3.16.7'
-''',
-        );
+''';
 
       // act, assert
       expect(


### PR DESCRIPTION
## Issue

- #138 

## Overview (Required)
yaml was used to convert the pubspecFile in the File system to yaml format. `loadYaml`
In order to maintain the previous behavior, we have implemented the actions performed by the yaml package manually
and have discontinued the yaml package.
In addition, because its use is limited, processing was limited to the bare minimum.


## Screenshot


<img src="https://github.com/user-attachments/assets/3f07b9c4-ba03-4388-8e79-afd4b0457c15" width="300" />