### PR TITLE
[GH-158] Change GitHub Actions version specification to Commit SHA specification

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,4 +9,5 @@ jobs:
   publish:
     permissions:
       id-token: write # Required for authentication using OIDC
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    # https://github.com/dart-lang/setup-dart
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # 1.7.1

--- a/.github/workflows/push-tag.yaml
+++ b/.github/workflows/push-tag.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # 2.0.2
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6
         with:
           app-id: ${{ secrets.APP_ID_OF_YUMEMI_TAG_PUSHER }}
           private-key: ${{ secrets.APP_PRIVATE_KEY_OF_YUMEMI_TAG_PUSHER }}

--- a/.github/workflows/push-tag.yaml
+++ b/.github/workflows/push-tag.yaml
@@ -17,12 +17,12 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # 2.0.2
         with:
           app-id: ${{ secrets.APP_ID_OF_YUMEMI_TAG_PUSHER }}
           private-key: ${{ secrets.APP_PRIVATE_KEY_OF_YUMEMI_TAG_PUSHER }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ steps.generate_token.outputs.token }}
       - name: Extract a version

--- a/.github/workflows/review-assign.yaml
+++ b/.github/workflows/review-assign.yaml
@@ -11,7 +11,8 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: hkusu/review-assign-action@v1
+       # https://github.com/hkusu/review-assign-action
+      - uses: hkusu/review-assign-action@5bee595fdb9765d4a0bd35724b6302fa15569158 # v1.4.0
         with:
           assignees: ${{ github.actor }}
           reviewers: ${{ vars.REVIEWERS }}

--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -21,7 +21,7 @@ jobs:
           git branch ${{ env.UPDATE_CONTRIBUTORS_BRANCH }}
           git push origin ${{ env.UPDATE_CONTRIBUTORS_BRANCH }}
       # https://github.com/BobAnkh/add-contributors
-      - uses: BobAnkh/add-contributors@v0.2.2
+      - uses: BobAnkh/add-contributors@vde6c43a0c154b093a210d8bdf7ab283aba8452dd # v0.2.2
         with:
           ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ env.UPDATE_CONTRIBUTORS_BRANCH }}

--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -12,7 +12,7 @@ jobs:
   add-contributors:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: aactions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Delete old branch (If it exists)
         run: git push origin --delete ${{ env.UPDATE_CONTRIBUTORS_BRANCH }}
         continue-on-error: true


### PR DESCRIPTION
## Issue

- close #158 

## Overview (Required)

- Change GitHub Actions version specification to Commit SHA specification
 - relevant section(prediction)
   - publish.yaml
   - push-tag.yaml
   - review-assign.yaml
   - update-contributors.yaml

## Links

- https://github.com/BobAnkh/add-contributors
  - https://github.com/BobAnkh/add-contributors/releases/tag/v0.2.2
- https://github.com/dart-lang/setup-dart
  - https://github.com/dart-lang/setup-dart/releases/tag/v1.7.1
- https://github.com/hkusu/review-assign-action
  -  https://github.com/hkusu/review-assign-action/releases/tag/v1.4.0
- https://github.com/actions/create-github-app-token
  - https://github.com/actions/create-github-app-token/releases/tag/v2.0.2

## Screenshot
None
