### PR TITLE
[143] Fixed a bug in check-lint-auto-approve that caused it to fire even when not automatically updated.

### DIFF
--- a/.github/workflows/check-lint-auto-approve.yaml
+++ b/.github/workflows/check-lint-auto-approve.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   auto-approve:
-    if: startsWith(github.head_ref, vars.AUTO_UPDATE_BRANCH_NAME)
+    if: contains(github.head_ref, vars.AUTO_UPDATE_BRANCH_NAME)
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/check-lint-auto-approve.yaml
+++ b/.github/workflows/check-lint-auto-approve.yaml
@@ -7,9 +7,7 @@ on:
 
 jobs:
   auto-approve:
-    env:
-      AUTO_UPDATE_BRANCH: ${{ secrets.AUTO_UPDATE_BRANCH_NAME }}
-    if: contains(github.head_ref, env.AUTO_UPDATE_BRANCH)
+    if: startsWith(github.head_ref, 'auto/update-lint-rules-')
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/check-lint-auto-approve.yaml
+++ b/.github/workflows/check-lint-auto-approve.yaml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   auto-approve:
-    if: contains(github.head_ref, ${{ vars.AUTO_UPDATE_BRANCH_NAME }})
+    # if: contains(github.head_ref, ${{ vars.AUTO_UPDATE_BRANCH_NAME }})
+    if: contains(github.head_ref, secrets.AUTO_UPDATE_BRANCH_NAME)
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/check-lint-auto-approve.yaml
+++ b/.github/workflows/check-lint-auto-approve.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   auto-approve:
-    if: startsWith(github.head_ref, 'auto/update-lint-rules-')
+    if: startsWith(github.head_ref, vars.AUTO_UPDATE_BRANCH_NAME)
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/check-lint-auto-approve.yaml
+++ b/.github/workflows/check-lint-auto-approve.yaml
@@ -7,8 +7,9 @@ on:
 
 jobs:
   auto-approve:
-    # if: contains(github.head_ref, ${{ vars.AUTO_UPDATE_BRANCH_NAME }})
-    if: contains(github.head_ref, secrets.AUTO_UPDATE_BRANCH_NAME)
+    env:
+      AUTO_UPDATE_BRANCH: ${{ secrets.AUTO_UPDATE_BRANCH_NAME }}
+    if: contains(github.head_ref, env.AUTO_UPDATE_BRANCH)
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
## Issue

- close #143 

## Overview (Required)

- Fixed a bug in check-lint-auto-approve that caused it to fire even when not automatically updated
  - First: trying to expand variables in the form ${{ vars.AUTO_UPDATE_BRANCH_NAME }} 
  - After fix: direct reference in the form vars.AUTO_UPDATE_BRANCH_NAME


## Links

- None

## Screenshot

- None
