### PR TITLE
Support for updating the version of the runner-image specified in runs-on

### DIFF
--- a/.github/workflows/check-lint-auto-approve.yaml
+++ b/.github/workflows/check-lint-auto-approve.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   auto-approve:
     if: contains(github.head_ref, vars.AUTO_UPDATE_BRANCH_NAME)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       contents: write

--- a/.github/workflows/push-tag.yaml
+++ b/.github/workflows/push-tag.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   push-tag:
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate a token
         id: generate_token

--- a/.github/workflows/review-assign.yaml
+++ b/.github/workflows/review-assign.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   assign:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       pull-requests: write

--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   add-contributors:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: aactions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Delete old branch (If it exists)

--- a/.github/workflows/update-lint-rules.yaml
+++ b/.github/workflows/update-lint-rules.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   update:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       contents: write


### PR DESCRIPTION
## Issue

- close #164 

## Overview (Required)

Support for updating the version of runner-image specified in runs-on of each GitHub workflow file (version specification).

Update to the latest version available on runner_image, which will be `Ubuntu 24.04


## Links

- https://github.com/actions/runner-images?tab=readme-ov-file


## Screenshot
- None
