### PR TITLE
Fixed typo in GitHub Actions

### DIFF
--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -12,7 +12,7 @@ jobs:
   add-contributors:
     runs-on: ubuntu-24.04
     steps:
-      - uses: aactions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Delete old branch (If it exists)
         run: git push origin --delete ${{ env.UPDATE_CONTRIBUTORS_BRANCH }}
         continue-on-error: true

--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -21,7 +21,7 @@ jobs:
           git branch ${{ env.UPDATE_CONTRIBUTORS_BRANCH }}
           git push origin ${{ env.UPDATE_CONTRIBUTORS_BRANCH }}
       # https://github.com/BobAnkh/add-contributors
-      - uses: BobAnkh/add-contributors@vde6c43a0c154b093a210d8bdf7ab283aba8452dd # v0.2.2
+      - uses: BobAnkh/add-contributors@de6c43a0c154b093a210d8bdf7ab283aba8452dd # v0.2.2
         with:
           ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ env.UPDATE_CONTRIBUTORS_BRANCH }}


### PR DESCRIPTION
## Issue

N/A

## Overview (Required)

- Fix typo in GitHub Actions workflow file
  - `aactions/checkout` → `actions/checkout`
  - `BobAnkh/add-contributors@vde6c43a` → `BobAnkh/add-contributors@de6c43a`（removed leading 'v'） 

## Links

- https://github.com/BobAnkh/add-contributors/tree/de6c43a0c154b093a210d8bdf7ab283aba8452dd/
- https://github.com/BobAnkh/add-contributors/commits/v0.2.2/

## Screenshot

N/A