### PR TITLE
ci: Add check-publish workflow

### DIFF
--- a/.github/workflows/check-publish.yaml
+++ b/.github/workflows/check-publish.yaml
@@ -1,0 +1,35 @@
+name: Check Publish on Release PR
+
+on:
+  pull_request:
+    branches:
+      - "main"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-publish:
+    if: startsWith(github.head_ref, 'release/')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Extract dart version
+        uses: blendfactory/dvm-config-action@1efe1a203d0a3a31bffd767b0affb251b54ff6bc # v2.0.0
+        id: dvm-config-action
+
+      - name: Set up dart
+        uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1.7.1
+        with:
+          sdk: ${{ steps.dvm-config-action.outputs.dart-sdk-version }}
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Dry run publish
+        run: dart pub publish --dry-run


### PR DESCRIPTION
## Issue

- close #175 

## Overview (Required)

This pull request introduces a new GitHub Actions workflow to check the publishability of the package when a pull request is created or updated from a `release/xxx` branch to the `main` branch.

### Details

- Adds a workflow (`check-publish.yaml`) that runs `dart pub publish --dry-run` on PRs from `release/` branches targeting `main`.
- The workflow ensures that any potential issues with publishing to pub.dev are detected before merging the release branch.
- If the dry-run fails, the PR check will fail, preventing the merge and allowing issues to be addressed early.

## Links

N/A

## Screenshot

N/A